### PR TITLE
Feature/logout

### DIFF
--- a/dafni_cli/dafni.py
+++ b/dafni_cli/dafni.py
@@ -1,6 +1,6 @@
 import click
 from dafni_cli.get import get
-from dafni_cli.login import login
+from dafni_cli.login import login, logout
 
 
 @click.group()
@@ -10,6 +10,7 @@ def dafni():
 
 
 dafni.add_command(login)
+dafni.add_command(logout)
 dafni.add_command(get)
 
 if __name__ == "__main__":

--- a/dafni_cli/login.py
+++ b/dafni_cli/login.py
@@ -143,3 +143,22 @@ def login():
                 jwt_dict["user_name"], jwt_dict["user_id"]
             )
         )
+
+@click.command()
+def logout():
+    """Function to handle logging out of the DAFNI
+    CLI. This will involve removing the cached JWT
+    generated during the login process.
+    """
+    existing_jwt = read_jwt_file()
+    if existing_jwt:
+        path = os.path.join(os.getcwd(), JWT_FILENAME)
+        os.remove(path)
+        click.echo("Logout Complete")
+        click.echo(
+            "user name: {0}, user id: {1}".format(
+                existing_jwt["user_name"], existing_jwt["user_id"]
+            )
+        )
+    else:
+        click.echo("Already logged out")

--- a/test/test_login.py
+++ b/test/test_login.py
@@ -325,3 +325,53 @@ class TestLogin:
                 processed_jwt_fixture["user_name"], processed_jwt_fixture["user_id"]
             )
         )
+
+
+@patch("dafni_cli.login.os.remove")
+@patch("dafni_cli.login.os.getcwd")
+@patch("dafni_cli.login.read_jwt_file")
+class TestLogout:
+    """Test class to test the logout command"""
+
+    def test_user_informed_already_logged_out_if_no_cached_jwt_found(
+        self, mock_jwt, mock_getcwd, mock_remove
+    ):
+        # SETUP
+        runner = CliRunner()
+        mock_jwt.return_value = None
+
+        # CALL
+        result = runner.invoke(login.logout)
+
+        # ASSERT
+        assert result.stdout == "Already logged out\n"
+
+    def test_cached_jwt_file_removed_if_jwt_file_found(
+        self, mock_jwt, mock_getcwd, mock_remove, processed_jwt_fixture
+    ):
+        # SETUP
+        runner = CliRunner()
+        mock_jwt.return_value = processed_jwt_fixture
+        mock_getcwd.return_value = "\\path\\to\\file"
+
+        # CALL
+        runner.invoke(login.logout)
+
+        # ASSERT
+        mock_remove.assert_called_once_with("\\path\\to\\file\\" + JWT_FILENAME)
+
+    def test_cached_jwt_details_printed_after_file_removed(
+        self, mock_jwt, mock_getcwd, mock_remove, processed_jwt_fixture
+    ):
+        # SETUP
+        runner = CliRunner()
+        mock_jwt.return_value = processed_jwt_fixture
+        mock_getcwd.return_value = "\\path\\to\\file"
+
+        # CALL
+        result = runner.invoke(login.logout)
+
+        # ASSERT
+        assert result.stdout == (
+            "Logout Complete\nuser name: john-doe, user id: e1092c3e-be04-4c19-957f-cd884e53447e\n"
+        )


### PR DESCRIPTION
Adding in logout command to remove the cached JWT file, if it exists
- displays "Already logged out" if no file found
- displays "Logout Complete", "user name: {user name}, user id: {user id}" if file found