### PR TITLE
Tests for get model

### DIFF
--- a/dafni_cli/API_requests.py
+++ b/dafni_cli/API_requests.py
@@ -52,7 +52,7 @@ def get_single_model_dict(jwt: str, model_version_id: str) -> dict:
     return dafni_get_request(url, jwt)
 
 
-def get_model_metadata_dicts(jwt: str, model_version_id: str) -> dict:
+def get_model_metadata_dict(jwt: str, model_version_id: str) -> dict:
     """Function to call the get model metadata endpoint and return the resulting dictionary.
 
     Args:

--- a/dafni_cli/get.py
+++ b/dafni_cli/get.py
@@ -1,5 +1,6 @@
 import click
 from click import Context
+from typing import List
 
 from dafni_cli.login import check_for_jwt_file
 from dafni_cli.API_requests import get_models_dicts
@@ -57,9 +58,9 @@ def models(ctx: Context, long: bool, creation_date: str, publication_date: str):
 
 
 @get.command()
-@click.argument("version-id", nargs=-1)
+@click.argument("version-id", nargs=-1, required=True)
 @click.pass_context
-def model(ctx: Context, version_id: str):
+def model(ctx: Context, version_id: List[str]):
     """Displays the metadata for one or more model versions
 
     Args:

--- a/dafni_cli/login.py
+++ b/dafni_cli/login.py
@@ -144,6 +144,7 @@ def login():
             )
         )
 
+
 @click.command()
 def logout():
     """Function to handle logging out of the DAFNI

--- a/dafni_cli/model.py
+++ b/dafni_cli/model.py
@@ -6,12 +6,9 @@ from dafni_cli.model_metadata import ModelMetadata
 from dafni_cli.consts import CONSOLE_WIDTH, TAB_SPACE
 from dafni_cli.API_requests import (
     get_single_model_dict,
-    get_model_metadata_dicts,
+    get_model_metadata_dict,
 )
-from dafni_cli.utils import (
-    prose_print,
-
-)
+from dafni_cli.utils import prose_print
 
 
 class Model:
@@ -83,7 +80,7 @@ class Model:
         Args:
             jwt_string (str): JWT for login purposes
         """
-        metadata_dict = get_model_metadata_dicts(jwt_string, self.version_id)
+        metadata_dict = get_model_metadata_dict(jwt_string, self.version_id)
         self.metadata = ModelMetadata(metadata_dict)
 
     def filter_by_date(self, key: str, date: str) -> bool:

--- a/test/test_api_requests.py
+++ b/test/test_api_requests.py
@@ -92,7 +92,7 @@ class TestGetSingleModelDict:
 
 @patch("dafni_cli.API_requests.dafni_get_request")
 class TestModelMetaDataDicts:
-    """Test class to test the get_model_metadata_dicts functionality"""
+    """Test class to test the get_model_metadata_dict functionality"""
 
     def test_dafni_get_request_called_correctly(self, mock_get):
 
@@ -102,7 +102,7 @@ class TestModelMetaDataDicts:
         model_version = "version_1"
 
         # CALL
-        result = API_requests.get_model_metadata_dicts(JWT, model_version)
+        result = API_requests.get_model_metadata_dict(JWT, model_version)
 
         # ASSERT
         assert result == {"key": "value"}

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -103,7 +103,7 @@ class TestModel:
             mock_get.assert_called_once_with(jwt_string, version_id)
             mock_details.assert_called_once_with(model_dict)
 
-    @patch("dafni_cli.model.get_model_metadata_dicts")
+    @patch("dafni_cli.model.get_model_metadata_dict")
     class TestGetMetadata:
         """Test class to test the Model.get_metadata() functionality"""
 
@@ -238,7 +238,7 @@ class TestModel:
                 ),
                 call("Summary: summary"),
                 call("Description: "),
-                call("")
+                call(""),
             ]
             assert mock_prose.called_once_with("description", CONSOLE_WIDTH)
 

--- a/test/test_model_metadata.py
+++ b/test/test_model_metadata.py
@@ -209,7 +209,9 @@ class TestModelMetadata:
         class TestFormatDataslots:
             """Test class to test the ModelMetadata.format_dataslots() functionality"""
 
-            def test_dataslots_string_is_formatted_properly_if_it_exists(self, get_model_metadata_fixture):
+            def test_dataslots_string_is_formatted_properly_if_it_exists(
+                self, get_model_metadata_fixture
+            ):
                 # SETUP
                 metadata_dict = get_model_metadata_fixture
                 metadata = model_metadata.ModelMetadata(metadata_dict)
@@ -233,7 +235,9 @@ class TestModelMetadata:
                 # ASSERT
                 assert dataslot_string == expected
 
-            def test_none_returned_if_there_are_no_dataslots(self, get_model_metadata_fixture):
+            def test_none_returned_if_there_are_no_dataslots(
+                self, get_model_metadata_fixture
+            ):
                 # SETUP
                 metadata_dict = get_model_metadata_fixture
                 del metadata_dict["spec"]["inputs"]["dataslots"]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -19,11 +19,11 @@ class TestProsePrint:
         utils.prose_print(string, 10)
 
         # ASSERT
-        assert mock_click.echo.call_args_list == [
-            call(string)
-        ]
+        assert mock_click.echo.call_args_list == [call(string)]
 
-    def test_string_without_line_breaks_or_spaces_is_split_correctly_and_printed_sequentially(self, mock_click):
+    def test_string_without_line_breaks_or_spaces_is_split_correctly_and_printed_sequentially(
+        self, mock_click
+    ):
         # SETUP
         string = "123456"
 
@@ -37,7 +37,9 @@ class TestProsePrint:
             call("56"),
         ]
 
-    def test_string_with_space_before_width_but_no_line_break_splits_at_space(self, mock_click):
+    def test_string_with_space_before_width_but_no_line_break_splits_at_space(
+        self, mock_click
+    ):
         # SETUP
         string = "12 3456"
 
@@ -136,7 +138,9 @@ class TestOptionalColumn:
         # ASSERT
         assert entry == "     value"
 
-    def test_if_key_exists_and_no_column_width_specified_string_with_no_extra_spaces_is_returned(self):
+    def test_if_key_exists_and_no_column_width_specified_string_with_no_extra_spaces_is_returned(
+        self,
+    ):
         # SETUP
         key = "key"
         value = "value"
@@ -148,7 +152,9 @@ class TestOptionalColumn:
         # ASSERT
         assert entry == "value"
 
-    def test_if_key_does_not_exist_but_column_width_specified_then_blank_space_of_specified_length_is_returned(self):
+    def test_if_key_does_not_exist_but_column_width_specified_then_blank_space_of_specified_length_is_returned(
+        self,
+    ):
         # SETUP
         key = "key"
         dictionary = {"other_key": "value"}
@@ -160,7 +166,9 @@ class TestOptionalColumn:
         # ASSERT
         assert entry == " " * 8
 
-    def test_if_key_does_not_exist_and_column_width_not_specified_then_empty_string_returned(self):
+    def test_if_key_does_not_exist_and_column_width_not_specified_then_empty_string_returned(
+        self,
+    ):
         # SETUP
         key = "key"
         dictionary = {"other_key": "value"}


### PR DESCRIPTION
I've added tests for `get model <version-id>` for when one ID is provided, when two are provided, and that an error occurs when there are no IDs provided.

I also updated the formatting using python black as I think I forgot to do that on the last PR.