### PR TITLE
Bug/model/type error for get model

### DIFF
--- a/dafni_cli/model.py
+++ b/dafni_cli/model.py
@@ -136,20 +136,3 @@ class Model:
         if self.metadata.outputs:
             click.echo("Outputs: ")
             click.echo(self.metadata.format_outputs())
-
-
-if __name__ == "__main__":
-    jwt = "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJsb2dpbi1hcHAtand0IiwiZXhwIjoxNjE1ODEzNTgzLCJzdWIiOiI4ZDg1N2FjZi0yNjRmLTQ5Y2QtOWU3Zi0xZTlmZmQzY2U2N2EifQ.pdC8py7YTu-KhVCn2_A3MCJjnhE13JKkXFUqvzBAPQA"
-    version_id = []
-    #version_id.append("0b4b0d0a-5b05-4e14-b382-9a5c9082315b")  # COVID
-    #version_id.append("a2dc91ea-c243-4232-8d2e-f951fc5f8248")  # Transform
-    #version_id.append("d0942631-158c-4cd2-a75f-ec7ec5798381")  # SIMIM
-    #version_id.append("399cdaac-aab6-494d-870a-66de8a4217bb")  # Spatial Housing
-    #version_id.append("ef4b22c8-63be-4b53-ba7c-c1cf301774b2")  # Non-spatial Housing
-    #version_id.append("9de4ad50-fd98-4def-9bfc-39378854e6a1")  # 5G
-    version_id.append("d50776e8-db8a-4fa6-93d7-c8fb15634e76")  # Fibionacci
-    for id in version_id:
-        model = Model()
-        model.get_details_from_id(jwt, id)
-        model.get_metadata(jwt)
-        model.output_model_metadata()

--- a/dafni_cli/model.py
+++ b/dafni_cli/model.py
@@ -136,3 +136,20 @@ class Model:
         if self.metadata.outputs:
             click.echo("Outputs: ")
             click.echo(self.metadata.format_outputs())
+
+
+if __name__ == "__main__":
+    jwt = "JWT eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJsb2dpbi1hcHAtand0IiwiZXhwIjoxNjE1ODEzNTgzLCJzdWIiOiI4ZDg1N2FjZi0yNjRmLTQ5Y2QtOWU3Zi0xZTlmZmQzY2U2N2EifQ.pdC8py7YTu-KhVCn2_A3MCJjnhE13JKkXFUqvzBAPQA"
+    version_id = []
+    #version_id.append("0b4b0d0a-5b05-4e14-b382-9a5c9082315b")  # COVID
+    #version_id.append("a2dc91ea-c243-4232-8d2e-f951fc5f8248")  # Transform
+    #version_id.append("d0942631-158c-4cd2-a75f-ec7ec5798381")  # SIMIM
+    #version_id.append("399cdaac-aab6-494d-870a-66de8a4217bb")  # Spatial Housing
+    #version_id.append("ef4b22c8-63be-4b53-ba7c-c1cf301774b2")  # Non-spatial Housing
+    #version_id.append("9de4ad50-fd98-4def-9bfc-39378854e6a1")  # 5G
+    version_id.append("d50776e8-db8a-4fa6-93d7-c8fb15634e76")  # Fibionacci
+    for id in version_id:
+        model = Model()
+        model.get_details_from_id(jwt, id)
+        model.get_metadata(jwt)
+        model.output_model_metadata()

--- a/dafni_cli/utils.py
+++ b/dafni_cli/utils.py
@@ -47,10 +47,11 @@ def optional_column(
         entry (str): Either the value of the entry to be put into the table, column_width number of spaces
     """
     if key in dictionary:
+        entry_string = str(dictionary[key])
         if column_width > 0:
-            entry = f"{dictionary[key]:{alignment}{column_width}}"
+            entry = f"{entry_string:{alignment}{column_width}}"
         elif column_width == 0:
-            entry = f"{dictionary[key]}"
+            entry = entry_string
         else:
             raise ValueError("Column width for optional column must be non-negative")
     else:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -111,10 +111,20 @@ class TestProcessResponseToClassList:
 class TestOptionalColumn:
     """Test class to test the optional_column() functionality"""
 
-    def test_if_key_exists_value_is_returned_with_correct_width(self):
+    @pytest.mark.parametrize(
+        "value, result",
+        [
+            ("value", "value     "),
+            (1, "1         "),
+            (1.0, "1.0       "),
+            ({'sub_key': 'value'}, "{'sub_key': 'value'}"),
+            ({}, "{}        "),
+            (True, "True      "),
+        ],
+    )
+    def test_if_key_exists_value_is_returned_with_correct_width(self, value, result):
         # SETUP
         key = "key"
-        value = "value"
         dictionary = {key: value}
         column_width = 10
 
@@ -122,12 +132,22 @@ class TestOptionalColumn:
         entry = utils.optional_column(dictionary, key, column_width)
 
         # ASSERT
-        assert entry == "value     "
+        assert entry == result
 
-    def test_if_key_exists_value_is_returned_with_correct_width_and_alignment(self):
+    @pytest.mark.parametrize(
+        "value, result",
+        [
+            ("value", "     value"),
+            (1, "         1"),
+            (1.0, "       1.0"),
+            ({'sub_key': 'value'}, "{'sub_key': 'value'}"),
+            ({}, "        {}"),
+            (True, "      True"),
+        ],
+    )
+    def test_if_key_exists_value_is_returned_with_correct_width_and_alignment(self, value, result):
         # SETUP
         key = "key"
-        value = "value"
         dictionary = {key: value}
         column_width = 10
         alignment = ">"
@@ -136,21 +156,33 @@ class TestOptionalColumn:
         entry = utils.optional_column(dictionary, key, column_width, alignment)
 
         # ASSERT
-        assert entry == "     value"
+        assert entry == result
 
+    @pytest.mark.parametrize(
+        "value, result",
+        [
+            ("value", "value"),
+            (1, "1"),
+            (1.0, "1.0"),
+            ({'sub_key': 'value'}, "{'sub_key': 'value'}"),
+            ({}, "{}"),
+            (True, "True"),
+        ],
+    )
     def test_if_key_exists_and_no_column_width_specified_string_with_no_extra_spaces_is_returned(
         self,
+        value,
+        result
     ):
         # SETUP
         key = "key"
-        value = "value"
         dictionary = {key: value}
 
         # CALL
         entry = utils.optional_column(dictionary, key)
 
         # ASSERT
-        assert entry == "value"
+        assert entry == result
 
     def test_if_key_does_not_exist_but_column_width_specified_then_blank_space_of_specified_length_is_returned(
         self,

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -119,6 +119,8 @@ class TestOptionalColumn:
             (1.0, "1.0       "),
             ({'sub_key': 'value'}, "{'sub_key': 'value'}"),
             ({}, "{}        "),
+            ([], "[]        "),
+            ([1, 2], "[1, 2]    "),
             (True, "True      "),
         ],
     )
@@ -142,6 +144,8 @@ class TestOptionalColumn:
             (1.0, "       1.0"),
             ({'sub_key': 'value'}, "{'sub_key': 'value'}"),
             ({}, "        {}"),
+            ([], "        []"),
+            ([1, 2], "    [1, 2]"),
             (True, "      True"),
         ],
     )
@@ -166,6 +170,8 @@ class TestOptionalColumn:
             (1.0, "1.0"),
             ({'sub_key': 'value'}, "{'sub_key': 'value'}"),
             ({}, "{}"),
+            ([], "[]"),
+            ([1, 2], "[1, 2]"),
             (True, "True"),
         ],
     )


### PR DESCRIPTION
The bug was due to me not realising that a default value could be a dictionary. This is fixed by converting the value from the dictionary passed to `optional_column` being converted to a string first.
Tests have been added to `test_utils/TestOptionalColumn` to ensure this works for all the expected data types: boolean, string, number, integer and json.