### PR TITLE
Fixing 500 error returned from using date filters on datasets

### DIFF
--- a/dafni_cli/datasets/dataset_filtering.py
+++ b/dafni_cli/datasets/dataset_filtering.py
@@ -23,7 +23,7 @@ def process_datasets_filters(
         filters["search_text"] = search_terms
 
     if start or end:
-        date_filter = {}
+        date_filter = {"data_with_no_date": False}
         if start:
             date_filter["begin"] = process_date_filter(start)
         if end:

--- a/test/datasets/test_dataset_filtering.py
+++ b/test/datasets/test_dataset_filtering.py
@@ -13,13 +13,13 @@ class TestProcessDatasetsFiltering:
         [
             (None, None, None, {}),
             ("DAFNI Search", None, None, {"search_text": "DAFNI Search"}),
-            (None, "Start Date", None, {"date_range": {"begin": "Start Date"}}),
-            (None, None, "End Date", {"date_range": {"end": "End Date"}}),
+            (None, "Start Date", None, {"date_range": {"begin": "Start Date", "data_with_no_date": False}}),
+            (None, None, "End Date", {"date_range": {"end": "End Date", "data_with_no_date": False}}),
             (
                 "DAFNI Search",
                 None,
                 "End Date",
-                {"search_text": "DAFNI Search", "date_range": {"end": "End Date"}},
+                {"search_text": "DAFNI Search", "date_range": {"end": "End Date", "data_with_no_date": False}},
             ),
             (
                 "DAFNI Search",
@@ -27,7 +27,7 @@ class TestProcessDatasetsFiltering:
                 "End Date",
                 {
                     "search_text": "DAFNI Search",
-                    "date_range": {"begin": "Start Date", "end": "End Date"},
+                    "date_range": {"begin": "Start Date", "end": "End Date", "data_with_no_date": False},
                 },
             ),
         ],ids=[


### PR DESCRIPTION
Set `date_filter` to be `{'data_with_no_date': False}` in `dataset_filtering.py`.
The expected return values in the tests have been updated accordingly.