### PR TITLE
bug fix - dataset get call

### DIFF
--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -46,12 +46,12 @@ class DataFile:
         Args:
             file_dict (dict): [description]
         """
-        self.name = check_key_in_dict(file_dict, "spdx:fileName")
+        self.name = check_key_in_dict(file_dict, ["spdx:fileName"])
         self.size = process_file_size(
-            check_key_in_dict(file_dict, "dcat:byteSize", default=None)
+            check_key_in_dict(file_dict, ["dcat:byteSize"], default=None)
         )
         self.format = DATA_FORMATS.get(
-            check_key_in_dict(file_dict, "dcat:mediaType"), ""
+            check_key_in_dict(file_dict, ["dcat:mediaType"]), ""
         )
 
 

--- a/test/datasets/test_dataset_metadata.py
+++ b/test/datasets/test_dataset_metadata.py
@@ -68,9 +68,9 @@ class TestDataFile:
 
             # ASSERT
             assert mock_check.call_args_list == [
-                call(file_dict, "spdx:fileName"),
-                call(file_dict, "dcat:byteSize", default=None),
-                call(file_dict, "dcat:mediaType"),
+                call(file_dict, ["spdx:fileName"]),
+                call(file_dict, ["dcat:byteSize"], default=None),
+                call(file_dict, ["dcat:mediaType"]),
             ]
             mock_process.assert_called_once_with("Mock Check")
 


### PR DESCRIPTION
Added in fix for missing table names and data in the dafni get dataset call

Rebuilt into a pip package and confirmed table now displays as expected