### PR TITLE
Feature/datasets version history

### DIFF
--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -87,9 +87,7 @@ class DatasetMetadata:
         update (str): Update Frequency
     """
 
-    def __init__(
-        self, dataset_dict: Optional[dict] = None, version_id: Optional[str] = None
-    ):
+    def __init__(self, dataset_dict: Optional[dict] = None):
         """DatasetMetadata constructor"""
         self.created = None
         self.creator = None
@@ -113,11 +111,9 @@ class DatasetMetadata:
         self.version_id = None
 
         if dataset_dict:
-            self.set_details_from_dict(dataset_dict, version_id)
+            self.set_details_from_dict(dataset_dict)
 
-    def set_details_from_dict(
-        self, dataset_dict: dict, version_id: Optional[str] = None
-    ):
+    def set_details_from_dict(self, dataset_dict: dict):
         """Helper function to populate the DatasetMetadata details
         based on a given DAFNI Dataset metadata client model
 
@@ -158,11 +154,9 @@ class DatasetMetadata:
         self.update = check_key_in_dict(dataset_dict, ["dct:accrualPeriodicity"])
 
         # Version History Fields
-        self.dataset_id = check_key_in_dict(
-            dataset_dict, ["version_history", "dataset_uuid"]
-        )
+        self.dataset_id = check_key_in_dict(dataset_dict, ["@id", "dataset_uuid"])
         self.title = check_key_in_dict(dataset_dict, ["dct:title"])
-        self.version_id = version_id
+        self.version_id = check_key_in_dict(dataset_dict, ["@id", "version_uuid"])
 
     def output_metadata_details(self, long: bool = False):
         """Function to output details relating to the Dataset.

--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -2,7 +2,7 @@ from dateutil.parser import isoparse
 import click
 from typing import Optional
 
-from dafni_cli.consts import CONSOLE_WIDTH, DATA_FORMATS
+from dafni_cli.consts import CONSOLE_WIDTH, DATA_FORMATS, TAB_SPACE
 from dafni_cli.utils import (
     check_key_in_dict,
     process_dict_datetime,
@@ -86,7 +86,9 @@ class DatasetMetadata:
         update (str): Update Frequency
     """
 
-    def __init__(self, dataset_dict: Optional[dict] = None):
+    def __init__(
+        self, dataset_dict: Optional[dict] = None, version_id: Optional[str] = None
+    ):
         """DatasetMetadata constructor"""
         self.created = None
         self.creator = None
@@ -105,11 +107,16 @@ class DatasetMetadata:
         self.language = None
         self.standard = None
         self.update = None
+        self.title = None
+        self.id = None
+        self.version_id = None
 
         if dataset_dict:
-            self.set_details_from_dict(dataset_dict)
+            self.set_details_from_dict(dataset_dict, version_id)
 
-    def set_details_from_dict(self, dataset_dict: dict):
+    def set_details_from_dict(
+        self, dataset_dict: dict, version_id: Optional[str] = None
+    ):
         """Helper function to populate the DatasetMetadata details
         based on a given DAFNI Dataset metadata client model
 
@@ -148,6 +155,11 @@ class DatasetMetadata:
         self.language = check_key_in_dict(dataset_dict, ["dct:language"])
         self.standard = check_key_in_dict(dataset_dict, ["dct:conformsTo", "label"])
         self.update = check_key_in_dict(dataset_dict, ["dct:accrualPeriodicity"])
+
+        # Version History Fields
+        self.id = check_key_in_dict(dataset_dict, ["version_history", "dataset_uuid"])
+        self.version_id = version_id
+        self.title = check_key_in_dict(dataset_dict, ["dct:title"])
 
     def output_metadata_details(self, long: bool = False):
         """Function to output details relating to the Dataset.
@@ -204,3 +216,14 @@ class DatasetMetadata:
         click.echo(f"Language: {self.language}")
         click.echo(f"Standard: {self.standard}")
         click.echo(f"Update Frequency: {self.update}")
+
+    def output_version_details(self):
+        """Prints relevant dataset attributes to command line"""
+        click.echo(f"\nTitle: {self.title}")
+        click.echo(f"ID: {self.id}")
+        click.echo(f"Version ID: {self.version_id}")
+        click.echo(f"Publisher: {self.publisher}")
+        click.echo(f"From: {self.start_date}{TAB_SPACE}To: {self.end_date}")
+        click.echo("Description: ")
+        prose_print(self.description, CONSOLE_WIDTH)
+        click.echo("")

--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -2,6 +2,7 @@ from dateutil.parser import isoparse
 import click
 from typing import Optional
 
+from dafni_cli.api.datasets_api import get_latest_dataset_metadata
 from dafni_cli.consts import CONSOLE_WIDTH, DATA_FORMATS, TAB_SPACE
 from dafni_cli.utils import (
     check_key_in_dict,
@@ -108,7 +109,7 @@ class DatasetMetadata:
         self.standard = None
         self.update = None
         self.title = None
-        self.id = None
+        self.dataset_id = None
         self.version_id = None
 
         if dataset_dict:
@@ -157,9 +158,11 @@ class DatasetMetadata:
         self.update = check_key_in_dict(dataset_dict, ["dct:accrualPeriodicity"])
 
         # Version History Fields
-        self.id = check_key_in_dict(dataset_dict, ["version_history", "dataset_uuid"])
-        self.version_id = version_id
+        self.dataset_id = check_key_in_dict(
+            dataset_dict, ["version_history", "dataset_uuid"]
+        )
         self.title = check_key_in_dict(dataset_dict, ["dct:title"])
+        self.version_id = version_id
 
     def output_metadata_details(self, long: bool = False):
         """Function to output details relating to the Dataset.
@@ -220,10 +223,9 @@ class DatasetMetadata:
     def output_version_details(self):
         """Prints relevant dataset attributes to command line"""
         click.echo(f"\nTitle: {self.title}")
-        click.echo(f"ID: {self.id}")
+        click.echo(f"ID: {self.dataset_id}")
         click.echo(f"Version ID: {self.version_id}")
         click.echo(f"Publisher: {self.publisher}")
         click.echo(f"From: {self.start_date}{TAB_SPACE}To: {self.end_date}")
         click.echo("Description: ")
         prose_print(self.description, CONSOLE_WIDTH)
-        click.echo("")

--- a/dafni_cli/datasets/dataset_version_history.py
+++ b/dafni_cli/datasets/dataset_version_history.py
@@ -1,18 +1,52 @@
+from typing import Optional, List
+
 from dafni_cli.datasets.dataset_metadata import DatasetMetadata
 from dafni_cli.utils import check_key_in_dict
 from dafni_cli.api.datasets_api import get_latest_dataset_metadata
 
 
 class DatasetVersionHistory:
-    def __init__(self, jwt: str, version_history: dict):
+    """Class for processing Dataset Version History,
 
+    Methods:
+        __init__(jwt (str), metadata (dict)): DatasetVersionHistory constructor
+        set_details_from_dict(metadata (dict)): Function to set the class details from a given dict
+        process_version_history(jwt (str), dataset (dict)): Iterates through all versions and outputs details
+
+    Attributes:
+        jwt (str): Users DAFNI JWT
+        dataset_id (str): Dataset ID
+        versions (List[dict]): List of associated Version dicts
+        version_ids (List[str]): List of Version IDs
+    """
+
+    def __init__(self, jwt: Optional[str] = None, metadata: Optional[dict] = None):
+        """DatasetVersionHistory constructor
+
+        Args:
+            jwt (Optional[str], optional): Users DAFNI JWT. Defaults to None.
+            metadata (Optional[dict], optional): Dataset Metadata response. Defaults to None.
+        """
         self.jwt = jwt
-        self.datasets = []
+        self.dataset_id = None
+        self.versions = None
+        self.version_ids = None
+
+        if metadata:
+            self.set_details_from_dict(metadata)
+
+    def set_details_from_dict(self, metadata: dict):
+        """Helper function to populate the DatasetVersionHistory details
+        based on a given DAFNI Dataset Metadata response
+
+        Args:
+            metadata (dict): DAFNI Dataset Metadata response
+        """
         self.dataset_id = check_key_in_dict(
-            version_history, ["version_history", "dataset_uuid"]
+            metadata, ["version_history", "dataset_uuid"]
         )
         self.versions = check_key_in_dict(
-            version_history, ["version_history", "versions"], default=[]
+            metadata, ["version_history", "versions"], default=[]
         )
         self.version_ids = [
             check_key_in_dict(version, ["version_uuid"], default=None)
@@ -20,6 +54,10 @@ class DatasetVersionHistory:
         ]
 
     def process_version_history(self):
+        """Function iterates through all Version History ID's,
+        retrieves the associated Dataset Metadata, and outputs the Version details
+        to the command line
+        """
         for version_id in self.version_ids:
             metadata = get_latest_dataset_metadata(
                 self.jwt, self.dataset_id, version_id

--- a/dafni_cli/datasets/dataset_version_history.py
+++ b/dafni_cli/datasets/dataset_version_history.py
@@ -1,0 +1,28 @@
+from dafni_cli.datasets.dataset_metadata import DatasetMetadata
+from dafni_cli.utils import check_key_in_dict
+from dafni_cli.api.datasets_api import get_latest_dataset_metadata
+
+
+class DatasetVersionHistory:
+    def __init__(self, jwt: str, version_history: dict):
+
+        self.jwt = jwt
+        self.datasets = []
+        self.dataset_id = check_key_in_dict(
+            version_history, ["version_history", "dataset_uuid"]
+        )
+        self.versions = check_key_in_dict(
+            version_history, ["version_history", "versions"], default=[]
+        )
+        self.version_ids = [
+            check_key_in_dict(version, ["version_uuid"], default=None)
+            for version in self.versions
+        ]
+
+    def process_version_history(self):
+        for version_id in self.version_ids:
+            metadata = get_latest_dataset_metadata(
+                self.jwt, self.dataset_id, version_id
+            )
+            dataset_meta = DatasetMetadata(metadata, version_id=version_id)
+            dataset_meta.output_version_details()

--- a/dafni_cli/datasets/dataset_version_history.py
+++ b/dafni_cli/datasets/dataset_version_history.py
@@ -42,9 +42,7 @@ class DatasetVersionHistory:
         Args:
             metadata (dict): DAFNI Dataset Metadata response
         """
-        self.dataset_id = check_key_in_dict(
-            metadata, ["version_history", "dataset_uuid"]
-        )
+        self.dataset_id = check_key_in_dict(metadata, ["@id", "dataset_uuid"])
         self.versions = check_key_in_dict(
             metadata, ["version_history", "versions"], default=[]
         )
@@ -62,5 +60,5 @@ class DatasetVersionHistory:
             metadata = get_latest_dataset_metadata(
                 self.jwt, self.dataset_id, version_id
             )
-            dataset_meta = DatasetMetadata(metadata, version_id=version_id)
+            dataset_meta = DatasetMetadata(metadata)
             dataset_meta.output_version_details()

--- a/dafni_cli/get.py
+++ b/dafni_cli/get.py
@@ -142,6 +142,7 @@ def datasets(
 @get.command()
 @click.option(
     "--version-history/--metadata",
+    "-v/-m",
     default=False,
     help="Whether to display the version history of a dataset instead of the metadata",
 )

--- a/dafni_cli/get.py
+++ b/dafni_cli/get.py
@@ -4,7 +4,11 @@ from typing import List, Optional
 
 from dafni_cli.api.datasets_api import get_all_datasets, get_latest_dataset_metadata
 from dafni_cli.api.models_api import get_models_dicts
-from dafni_cli.datasets import dataset_filtering, dataset_metadata
+from dafni_cli.datasets import (
+    dataset_filtering,
+    dataset_metadata,
+    dataset_version_history,
+)
 from dafni_cli.datasets.dataset import Dataset
 from dafni_cli.login import check_for_jwt_file
 from dafni_cli.model.model import Model
@@ -137,6 +141,11 @@ def datasets(
 
 @get.command()
 @click.option(
+    "--version-history/--metadata",
+    default=False,
+    help="Whether to display the version history of a dataset instead of the metadata",
+)
+@click.option(
     "--long/--short",
     "-l/-s",
     default=False,
@@ -146,7 +155,7 @@ def datasets(
 @click.argument("id", nargs=1, required=True, type=str)
 @click.argument("version-id", nargs=1, required=True, type=str)
 @click.pass_context
-def dataset(ctx: Context, id: str, version_id: str, long: bool):
+def dataset(ctx: Context, id: str, version_id: str, long: bool, version_history: bool):
     """Command to the the meta data relating to a given version of a dataset
 
     Args:
@@ -154,10 +163,17 @@ def dataset(ctx: Context, id: str, version_id: str, long: bool):
         id (str): Dataset ID
         version_id (str): Dataset version ID
         long (bool): Flag to view additional metadata attributes
+        version_history (bool): Flag to view version history in place of metadata
     """
     metadata = get_latest_dataset_metadata(ctx.obj["jwt"], id, version_id)
-    dataset_meta = dataset_metadata.DatasetMetadata(metadata)
-    dataset_meta.output_metadata_details(long)
+    if not version_history:
+        dataset_meta = dataset_metadata.DatasetMetadata(metadata)
+        dataset_meta.output_metadata_details(long)
+    else:
+        version_history = dataset_version_history.DatasetVersionHistory(
+            ctx.obj["jwt"], metadata
+        )
+        version_history.process_version_history()
 
 
 @get.command()

--- a/docs/dafni_cli.md
+++ b/docs/dafni_cli.md
@@ -141,7 +141,11 @@ If there is no valid JWT, the user will be prompted to login before the command 
 
   *Options*:
   - **--long**/**-l**: This prints out the additional Metadata fields: Themes, Publisher, Issued date, Rights, Language, Standards, & update frequency
-  
+  - **--version-history/-v**: If `--version-history`/`-v` is added as an option, the Title, ID, Version ID, Publisher, Date Range
+    and Description of each version of the Dataset will be displayed in reverse chronological order.
+  - **--metadata/-m**: If `--metadata`/`-m` is chosen, the metadata for that version of the model is displayed.
+    Default: `--metadata`. 
+
   Example output:
   <pre>
   Created: March 04 2021
@@ -171,7 +175,26 @@ If there is no valid JWT, the user will be prompted to login before the command 
   Language: en
   Standard: ISO 9001
   Update Frequency: Annually
-</pre>
+  </pre>
+  *With --version-history option*
+  <pre>
+  Title: An example workflow definition - new version
+  ID: 3469587b-c7c1-4686-bd4a-0c6a2c4cc34c
+  Version ID: a6360df5-ffb0-4d39-b1a0-0f8b5d8d7fa4
+  Publisher: DAFNI
+  From: March 01 2001    To: March 01 2020
+  Description:
+  Also fulling in the standard and update frequency fields.
+  Adding a new version
+  
+  Title: An example workflow definition
+  ID: 3469587b-c7c1-4686-bd4a-0c6a2c4cc34c
+  Version ID: a26983da-644f-4930-8d5a-06193240d7fe
+  Publisher: DAFNI
+  From: March 01 2001    To: March 01 2020
+  Description:
+  Also fulling in the standard and update frequency fields.
+  </pre>
 ___
 ### Upload
 

--- a/test/datasets/test_dataset_metadata.py
+++ b/test/datasets/test_dataset_metadata.py
@@ -144,27 +144,13 @@ class TestDatasetMeta:
             assert all(getattr(instance, key) == [] for key in array_keys)
 
         @patch.object(DatasetMetadata, "set_details_from_dict")
-        def test_set_details_from_dict_called_if_give_dict_with_default_version_id(
-            self, mock_set
-        ):
+        def test_set_details_from_dict_called_if_give_dict(self, mock_set):
             # SETUP
             dataset_dict = {"key": "value"}
             # CALL
             DatasetMetadata(dataset_dict)
             # ASSERT
-            mock_set.assert_called_once_with(dataset_dict, None)
-
-        @patch.object(DatasetMetadata, "set_details_from_dict")
-        def test_set_details_from_dict_called_if_give_dict_with_given_version_id(
-            self, mock_set
-        ):
-            # SETUP
-            dataset_dict = {"key": "value"}
-            version_id = "version"
-            # CALL
-            DatasetMetadata(dataset_dict, version_id)
-            # ASSERT
-            mock_set.assert_called_once_with(dataset_dict, version_id)
+            mock_set.assert_called_once_with(dataset_dict)
 
     class TestSetDetailsFromDict:
         """Test class to test the set_details_from_dict functionality"""
@@ -194,8 +180,7 @@ class TestDatasetMeta:
                 "Update",
                 "ID",
                 "Title",
-                ["Versions"],
-                "Version_IDs",
+                "Version_ID",
             )
 
             instance = DatasetMetadata()
@@ -228,8 +213,9 @@ class TestDatasetMeta:
                 call(dataset_dict, ["dct:language"]),
                 call(dataset_dict, ["dct:conformsTo", "label"]),
                 call(dataset_dict, ["dct:accrualPeriodicity"]),
-                call(dataset_dict, ["version_history", "dataset_uuid"]),
+                call(dataset_dict, ["@id", "dataset_uuid"]),
                 call(dataset_dict, ["dct:title"]),
+                call(dataset_dict, ["@id", "version_uuid"]),
             ]
 
             mock_datafile.assert_called_once_with({"key": "value"})

--- a/test/datasets/test_dataset_version_history.py
+++ b/test/datasets/test_dataset_version_history.py
@@ -59,7 +59,7 @@ class TestDatasetVersionHistory:
 
             # ASSERT
             assert mock_check.call_args_list == [
-                call(dataset_metadata_fixture, ["version_history", "dataset_uuid"]),
+                call(dataset_metadata_fixture, ["@id", "dataset_uuid"]),
                 call(
                     dataset_metadata_fixture,
                     ["version_history", "versions"],
@@ -123,5 +123,5 @@ class TestDatasetVersionHistory:
             ]
             assert mock_output.call_count == len(version_ids)
             assert mock_init.call_args_list == [
-                call("Meta data", version_id=version_id) for version_id in version_ids
+                call("Meta data") for version_id in version_ids
             ]

--- a/test/datasets/test_dataset_version_history.py
+++ b/test/datasets/test_dataset_version_history.py
@@ -1,0 +1,127 @@
+import pytest
+from mock import patch, call
+
+from dafni_cli.datasets.dataset_version_history import DatasetVersionHistory
+from dafni_cli.datasets.dataset_metadata import DatasetMetadata
+from dafni_cli.consts import CONSOLE_WIDTH, DATA_FORMATS, TAB_SPACE
+
+from test.fixtures.jwt_fixtures import JWT
+from test.fixtures.dataset_fixtures import (
+    dataset_metadata_fixture,
+    datafile_mock,
+    dataset_meta_mock,
+)
+
+
+class TestDatasetVersionHistory:
+    """Test class to test the DatasetVersionHistory Class"""
+
+    class TestInit:
+        """Test class to test the DataFile constructor"""
+
+        def test_dataset_version_history_has_expected_attributes(self):
+            # SETUP
+            expected_attributes = ["jwt", "dataset_id", "versions", "version_ids"]
+            # CALL
+            instance = DatasetVersionHistory()
+            # ASSERT
+            assert all(
+                getattr(instance, value) is None for value in expected_attributes
+            )
+
+        @patch.object(DatasetVersionHistory, "set_details_from_dict")
+        def test_helper_functions_called_correctly(
+            self, mock_set, dataset_metadata_fixture
+        ):
+            # SETUP
+            jwt = JWT
+            metadata = dataset_metadata_fixture
+            # CALL
+            instance = DatasetVersionHistory(jwt, metadata)
+            # ASSERT
+            assert instance.jwt == jwt
+            mock_set.assert_called_once_with(metadata)
+
+    class TestSetDetailsFromDict:
+        """Test class to test the set_details_from_dict functionality"""
+
+        @patch("dafni_cli.datasets.dataset_version_history.check_key_in_dict")
+        def test_helper_functions_called_correctly(
+            self, mock_check, dataset_metadata_fixture
+        ):
+            # SETUP
+            mock_check.side_effect = ("Dataset", ["Version_1"], "Version ID")
+
+            instance = DatasetVersionHistory()
+
+            # CALL
+            instance.set_details_from_dict(dataset_metadata_fixture)
+
+            # ASSERT
+            assert mock_check.call_args_list == [
+                call(dataset_metadata_fixture, ["version_history", "dataset_uuid"]),
+                call(
+                    dataset_metadata_fixture,
+                    ["version_history", "versions"],
+                    default=[],
+                ),
+                call("Version_1", ["version_uuid"], default=None),
+            ]
+
+        def test_attributes_set_correctly_with_valid_metadata(
+            self, dataset_metadata_fixture
+        ):
+            # SETUP
+            instance = DatasetVersionHistory()
+            # CALL
+            instance.set_details_from_dict(dataset_metadata_fixture)
+            # ASSERT
+
+            assert (
+                instance.dataset_id
+                == dataset_metadata_fixture["version_history"]["dataset_uuid"]
+            )
+            assert (
+                instance.versions
+                == dataset_metadata_fixture["version_history"]["versions"]
+            )
+            assert instance.version_ids == [
+                dataset_metadata_fixture["version_history"]["versions"][0][
+                    "version_uuid"
+                ]
+            ]
+
+    @patch.object(DatasetMetadata, "output_version_details")
+    @patch.object(DatasetMetadata, "__init__")
+    @patch("dafni_cli.datasets.dataset_version_history.get_latest_dataset_metadata")
+    class TestProcessVersionHistory:
+        """Test class to test the process_version_history functionality"""
+
+        @pytest.mark.parametrize(
+            "version_ids", [[], ["version_1"], ["version_1", "version_2"]]
+        )
+        def test_helper_functions_called_correctly(
+            self, mock_get, mock_init, mock_output, version_ids
+        ):
+            # SETUP
+            mock_init.return_value = None
+            mock_get.return_value = "Meta data"
+
+            instance = DatasetVersionHistory()
+
+            instance.version_ids = version_ids
+            instance.jwt = JWT
+            instance.dataset_id = "dataset id"
+
+            # CALL
+            instance.process_version_history()
+
+            # ASSERT
+            assert mock_get.call_args_list == [
+                call(instance.jwt, instance.dataset_id, version_id)
+                for version_id in version_ids
+            ]
+            assert mock_output.call_count == len(version_ids)
+            assert mock_init.call_args_list == [
+                call("Meta data", version_id=version_id) for version_id in version_ids
+            ]

--- a/test/fixtures/dataset_fixtures.py
+++ b/test/fixtures/dataset_fixtures.py
@@ -241,6 +241,9 @@ def dataset_meta_mock(
     language: str = "en",
     standard: str = "ISO 9001",
     update: str = "Annual",
+    title: str = "Title",
+    dataset_id: str = "Dataset ID",
+    version_id: str = "Version ID",
 ) -> DatasetMetadata:
     """Function to generate a DatasetMetadata object with mock data for testing
 
@@ -262,6 +265,9 @@ def dataset_meta_mock(
         language (str, optional): Associated Language. Defaults to "en".
         standard (str, optional): Associated standards. Defaults to "ISO 9001".
         update (str, optional): Frequency updated. Defaults to "Annual".
+        title (str, optional): Associated Title. Defaults to "en".
+        dataset_id (str, optional): Dataset ID. Defaults to "ISO 9001".
+        version_id (str, optional): Dataset Version ID. Defaults to "Annual".
 
     Returns:
         DatasetMetadata: DatasetMetadata object with mock data
@@ -284,5 +290,8 @@ def dataset_meta_mock(
     instance.language = language
     instance.standard = standard
     instance.update = update
+    instance.title = title
+    instance.dataset_id = dataset_id
+    instance.version_id = version_id
 
     return instance

--- a/test/fixtures/dataset_fixtures.py
+++ b/test/fixtures/dataset_fixtures.py
@@ -266,8 +266,8 @@ def dataset_meta_mock(
         standard (str, optional): Associated standards. Defaults to "ISO 9001".
         update (str, optional): Frequency updated. Defaults to "Annual".
         title (str, optional): Associated Title. Defaults to "en".
-        dataset_id (str, optional): Dataset ID. Defaults to "ISO 9001".
-        version_id (str, optional): Dataset Version ID. Defaults to "Annual".
+        dataset_id (str, optional): Dataset ID. Defaults to "Dataset ID".
+        version_id (str, optional): Dataset Version ID. Defaults to "Version ID".
 
     Returns:
         DatasetMetadata: DatasetMetadata object with mock data

--- a/test/fixtures/dataset_fixtures.py
+++ b/test/fixtures/dataset_fixtures.py
@@ -265,7 +265,7 @@ def dataset_meta_mock(
         language (str, optional): Associated Language. Defaults to "en".
         standard (str, optional): Associated standards. Defaults to "ISO 9001".
         update (str, optional): Frequency updated. Defaults to "Annual".
-        title (str, optional): Associated Title. Defaults to "en".
+        title (str, optional): Associated Title. Defaults to "Title".
         dataset_id (str, optional): Dataset ID. Defaults to "Dataset ID".
         version_id (str, optional): Dataset Version ID. Defaults to "Version ID".
 

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -7,7 +7,7 @@ from dafni_cli.model import (
     model,
     version_history,
 )
-from dafni_cli.datasets import dataset, dataset_metadata
+from dafni_cli.datasets import dataset, dataset_metadata, dataset_version_history
 from test.fixtures.jwt_fixtures import processed_jwt_fixture
 from test.fixtures.model_fixtures import get_models_list_fixture
 from test.fixtures.dataset_fixtures import (
@@ -506,19 +506,19 @@ class TestGet:
             # ASSERT
             mock_filter.assert_called_once_with(search, start, end)
 
-    @patch.object(dataset_metadata.DatasetMetadata, "output_metadata_details")
-    @patch.object(dataset_metadata.DatasetMetadata, "__init__")
     @patch("dafni_cli.get.get_latest_dataset_metadata")
     @patch("dafni_cli.get.check_for_jwt_file")
     class TestDataset:
         """Test class to test the get group dataset command"""
 
-        def test_get_dataset_called_with_jwt_from_context_with_default_long_value(
+        @patch.object(dataset_metadata.DatasetMetadata, "output_metadata_details")
+        @patch.object(dataset_metadata.DatasetMetadata, "__init__")
+        def test_get_dataset_called_with_jwt_from_context_with_default_long_and_version_flag_value(
             self,
-            mock_jwt,
-            mock_get,
             mock_init,
             mock_output,
+            mock_jwt,
+            mock_get,
             processed_jwt_fixture,
             dataset_metadata_fixture,
         ):
@@ -551,18 +551,22 @@ class TestGet:
 
             assert result.exit_code == 0
 
+        @pytest.mark.parametrize("metadata", ["--metadata","-m"])
         @pytest.mark.parametrize(
             "option, long",
             [("--short", False), ("-s", False), ("-l", True), ("--long", True)],
         )
-        def test_get_dataset_called_with_jwt_from_context_with_given_long_value(
+        @patch.object(dataset_metadata.DatasetMetadata, "output_metadata_details")
+        @patch.object(dataset_metadata.DatasetMetadata, "__init__")
+        def test_dataset_metadata_called_with_given_long_value_when_version_history_is_false(
             self,
-            mock_jwt,
-            mock_get,
             mock_init,
             mock_output,
+            mock_jwt,
+            mock_get,
             option,
             long,
+            metadata,
             processed_jwt_fixture,
             dataset_metadata_fixture,
         ):
@@ -586,14 +590,62 @@ class TestGet:
             # CALL
             result = runner.invoke(
                 get.get,
-                ["dataset", dataset_id, version_id, option],
+                ["dataset", dataset_id, version_id, option, metadata],
             )
-
+            print(result.stdout)
+            print(result.exc_info)
             # ASSERT
             mock_get.assert_called_once_with(
                 processed_jwt_fixture["jwt"], dataset_id, version_id
             )
             mock_init.assert_called_once_with(response)
             mock_output.assert_called_once_with(long)
+
+            assert result.exit_code == 0
+
+        @pytest.mark.parametrize("version_history", ["--version-history", "-v"])
+        @patch.object(
+            dataset_version_history.DatasetVersionHistory, "process_version_history"
+        )
+        @patch.object(dataset_version_history.DatasetVersionHistory, "__init__")
+        def test_dataset_version_history_called_when_version_history_true(
+            self,
+            mock_init,
+            mock_output,
+            mock_jwt,
+            mock_get,
+            version_history,
+            processed_jwt_fixture,
+            dataset_metadata_fixture,
+        ):
+            # SETUP
+            # setup get group command to set the context containing a JWT
+            mock_jwt.return_value = processed_jwt_fixture, False
+            # setup get_latest_dataset_metadata call
+            response = dataset_metadata_fixture
+            mock_get.return_value = response
+            # setup DatasetMetadata class
+            mock_init.return_value = None
+            mock_output.return_value = "Output"
+
+            # setup data
+            dataset_id = "0a0a0a0a-0a00-0a00-a000-0a0a0000000a"
+            version_id = "0a0a0a0a-0a00-0a00-a000-0a0a0000000b"
+
+            # Setup click
+            runner = CliRunner()
+
+            # CALL
+            result = runner.invoke(
+                get.get,
+                ["dataset", dataset_id, version_id, version_history],
+            )
+
+            # ASSERT
+            mock_get.assert_called_once_with(
+                processed_jwt_fixture["jwt"], dataset_id, version_id
+            )
+            mock_init.assert_called_once_with(processed_jwt_fixture["jwt"], response)
+            mock_output.assert_called_once_with()
 
             assert result.exit_code == 0


### PR DESCRIPTION
Added the --version-history/-v flag to the get dataset command, to display the version history instead of the metadata for the given dataset.

To Do:
- Update tests for get.py