### PR TITLE
Login bug - useful message when login fails

### DIFF
--- a/dafni_cli/commands/login.py
+++ b/dafni_cli/commands/login.py
@@ -25,9 +25,10 @@ def get_new_jwt(user_name: str, password: str) -> dict:
         headers={"Content-Type": "application/json"},
         allow_redirects=False,
     )
-    # Raise an exception if not successful
-    response.raise_for_status()
     # Get the JWT from the returned cookies
+    if JWT_COOKIE not in response.cookies:
+        click.echo("Login Failed: Please check your username and password")
+        exit(1)
     jwt = response.cookies[JWT_COOKIE]
 
     # process the new JWT


### PR DESCRIPTION
API returns a 200 if login unsuccessful, hadn't accomodated this is the original code.

Code now checks if a JWT has been returned, if not it displays a useful message saying login failed and exits. This solution is status code agnostic, so will not need updating it the API starts returning a 4** class status code for login failure