### PR TITLE
Updating readme with current status CORE-2936

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Datasets:
 * View specific dataset latest metadata - DONE (But have to specify ID of the latest version)
 * View version history for specific dataset (format as datasets available list) - DONE
 * View specific historical dataset version metadata (format as specific datasets latest metadata) - DONE
-* Download dataset data and metadata - BROKEN (and dataset zip only)
+* Download dataset data and metadata - BROKEN (fixed in https://github.com/NewcastleRSE/dafni-cli, is dataset zip only - metadata accessed separately)
 * Upload a new dataset - BROKEN (BrokenPipeError, also not clear how to define the json definition file)
 * Update dataset metadata
 * Update dataset data files to create new version

--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Models:
 * View specific model latest metadata (model definition file..?) - DONE
 * View version history for specific model (format as models available list) - DONE
 * View specific historical model version metadata (format as specific model latest metadata) - DONE
-* Upload a new model - DONE
+* Upload a new model - DONE (But need to get parent ID from JSON output or UI)
 
-Python packaging of CLI - DONE
+Python packaging of CLI
 
 Datasets:
 * List all datasets available to user - DONE
 * Filter list of datasets available to user. - DONE
-* View specific dataset latest metadata - DONE
+* View specific dataset latest metadata - DONE (But have to specify ID of the latest version)
 * View version history for specific dataset (format as datasets available list) - DONE
 * View specific historical dataset version metadata (format as specific datasets latest metadata) - DONE
-* Download dataset data and metadata - DONE
-* Upload a new dataset - DONE
+* Download dataset data and metadata - BROKEN (and dataset zip only)
+* Upload a new dataset - BROKEN (BrokenPipeError, also not clear how to define the json definition file)
 * Update dataset metadata
 * Update dataset data files to create new version
 
@@ -34,16 +34,17 @@ Deleting models and datasets
 * Delete a model - DONE
 * Delete a dataset
 * Delete a dataset version
+* Delete a workflow - DONE
 
 Workflows:
-* List all workflows available to user
-* Filter list of available workflows
-* View specific workflow metadata
+* List all workflows available to user - DONE
+* Filter list of available workflows - DONE
+* View specific workflow metadata - DONE
 * List all workflow instances available to user
 * Filter list of available workflow instances
 * View specific workflow instance metadata
-* Create workflow (using workflow definition file)
-* Edit workflow env params and create new workflow 
+* Create workflow (using workflow definition file) - BROKEN
+* Edit workflow env params and create new workflow
 * Edit workflow data slots and create new workflow
 
 Groups: 
@@ -114,7 +115,7 @@ _For more information contact Bethan Perkins / James Hannah / Brian Matthews_
 
 In November 2019 a forum was held with DAFNI pilot modellers in order to ascertain their priority features for the DAFNI platform. A DAFNI CLI was seen as a very valuable asset by the group. The following summarise the [notes taken during the forum](https://wiki.dafni.rl.ac.uk/display/DAFNIDEV/Observations+and+Conclusions).
 
-* THE CLI was consistenly prioritised above other features by all modellers
+* THE CLI was consistently prioritised above other features by all modellers
 * Modellers want to use a CLI for smoothly transitioning models from their local development environments to runtime/compute environments.
 * A CLI is seen as more "trustworthy" than a github
 * Modellers would use a CLI for the following:
@@ -143,7 +144,7 @@ _For more information, see link_
 
 ### 4. Food Network users
 
-A food network group are currently onboarding to DAFNI would like to use the platform as an area to host large datasets to support their work. The aspect which relates to a CLI is that of being able to autmoatically download latest results into a local web-app. 
+A food network group are currently onboarding to DAFNI would like to use the platform as an area to host large datasets to support their work. The aspect which relates to a CLI is that of being able to automatically download latest results into a local web-app. 
 
 
 ##### Key priority in this case

--- a/README.md
+++ b/README.md
@@ -1,5 +1,83 @@
 # The DAFNI CLI
 
+## Feature Priority
+From the use cases described above, the following list of features is defined. These are placed in priority order, taking in to account the use cases above as well as the work required to develop each feature. 
+
+Admin #1:
+* Log in (Log out should be automatic) - DONE 
+* See own user details  - DONE
+    + User Name
+    + User UUID
+
+Models:
+* List all models available to user - DONE
+* Filter list of models available to user - DONE
+* View specific model latest metadata (model definition file..?) - DONE
+* View version history for specific model (format as models available list) - DONE
+* View specific historical model version metadata (format as specific model latest metadata) - DONE
+* Upload a new model - DONE
+
+Python packaging of CLI - DONE
+
+Datasets:
+* List all datasets available to user - DONE
+* Filter list of datasets available to user. - DONE
+* View specific dataset latest metadata - DONE
+* View version history for specific dataset (format as datasets available list) - DONE
+* View specific historical dataset version metadata (format as specific datasets latest metadata) - DONE
+* Download dataset data and metadata - DONE
+* Upload a new dataset - DONE
+* Update dataset metadata
+* Update dataset data files to create new version
+
+Deleting models and datasets
+* Delete a model - DONE
+* Delete a dataset
+* Delete a dataset version
+
+Workflows:
+* List all workflows available to user
+* Filter list of available workflows
+* View specific workflow metadata
+* List all workflow instances available to user
+* Filter list of available workflow instances
+* View specific workflow instance metadata
+* Create workflow (using workflow definition file)
+* Edit workflow env params and create new workflow 
+* Edit workflow data slots and create new workflow
+
+Groups: 
+* List available groups
+* Create new group
+* View group information (all users and all shared assets with their permissions)
+* Add user(s) to a group (using id numbers?)
+* Remove user(s) from a group
+* Add a dataset to a group
+* Remove a dataset from a group
+* Add a model to a group
+* Remove a model from a group
+* Edit dataset permissions
+* Edit model permissions
+* Non-admin to leave a group
+* Edit group title
+* Edit group description
+
+Public:
+* Request global dataset permissions change -> Making them public / private (user P.O.V)
+
+Admin #2:
+* Search for another users' details
+
+Future:
+* Visualisation features (more thought needed here on what to pass back to the user - templates perhaps?)
+* Download models (not currently implemented)
+* Request a DAFNI account (not currently implemented)
+* Admin functions
+    + (e.g adding users? or confirming accounts?)
+    + managing assets - removing/changing asset visibility?
+    + service/outage message management?
+    + (far far future) billing/accounting
+​
 ## Use Cases
 The DAFNI CLI has been identified as requirement for in the following cases:
 ### 1. CERAF project
@@ -73,86 +151,6 @@ A food network group are currently onboarding to DAFNI would like to use the pla
 
 _For more information, contact Tom Gowland / Marion Samler_
 
-## Feature Priority
-From the use cases described above, the following list of features is defined. These are placed in priority order, taking in to account the use cases above as well as the work required to develop each feature. 
-
-Admin #1:
-* Log in (Log out should be automatic) - DONE 
-* See own user details  - DONE
-    + User Name
-    + User UUID
-
-Models:
-* List all models available to user - DONE
-* Filter list of models available to user - DONE
-* View specific model latest metadata (model definition file..?) - DONE
-* View version history for specific model (format as models available list) - DONE
-* View specific historical model version metadata (format as specific model latest metadata) - DONE
-* Upload a new model - DONE
-
-Python packaging of CLI - DONE
-
-Datasets:
-* List all datasets available to user - DONE
-* Filter list of datasets available to user. - DONE
-* View specific dataset latest metadata - DONE
-* View version history for specific dataset (format as datasets available list) - DONE
-* View specific historical dataset version metadata (format as specific datasets latest metadata) - DONE
-* Download dataset data and metadata - DONE
-* Upload a new dataset - DONE
-* Update dataset metadata
-* Update dataset data files to create new version
-
-Deleting models and datasets
-* Delete a model - DONE
-* Delete a dataset
-* Delete a dataset version]
-
-#TODO don't want people to be able to execute workflows from CLI
-Workflows:
-* List all workflows available to user
-* Filter list of available workflows
-* View specific workflow metadata
-* List all workflow instances available to user
-* Filter list of available workflow instances
-* View specific workflow instance metadata
-* Execute a workflow (without changing any properties of the workflow) to create a new instance
-* Create workflow (using workflow definition file)
-* Edit workflow env params and create new workflow 
-* Edit workflow data slots and create new workflow
-
-Groups: 
-* List available groups
-* Create new group
-* View group information (all users and all shared assets with their permissions)
-* Add user(s) to a group (using id numbers?)
-* Remove user(s) from a group
-* Add a dataset to a group
-* Remove a dataset from a group
-* Add a model to a group
-* Remove a model from a group
-* Edit dataset permissions
-* Edit model permissions
-* Non-admin to leave a group
-* Edit group title
-* Edit group description
-
-Public:
-* Request global dataset permissions change -> Making them public / private (user P.O.V)
-
-Admin #2:
-* Search for another users' details
-
-Future:
-* Visualsiation features (more thought needed here on what to pass back to the user - templates perhaps?)
-* Download models (not currently implemented)
-* Request a DAFNI account (not currently implemented)
-* Admin functions
-    + (e.g adding users? or confirming accounts?)
-    + managing assets - removing/changing asset visibility?
-    + service/outage message management?
-    + (far far future) billing/accounting
-​
 ## Functions
 * Will have to login to DAFNI with a `POST` to the login app with a username and password
 * When Keycloak comes in, there will be an OAuth flow to be able to do this in a better way

--- a/dafni_cli/api/workflows_api.py
+++ b/dafni_cli/api/workflows_api.py
@@ -12,7 +12,6 @@ from tokenize import String
 from requests import Response
 from typing import List, Tuple
 from pathlib import Path
-from multimethod import multimethod
 
 from dafni_cli.consts import WORKFLOWS_API_URL
 from dafni_cli.api.dafni_api import (

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
-from setuptools import setup, find_packages
-from os import path
+from pathlib import Path
 
-# TODO use pathlib
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "docs", "dafni_cli.md"), encoding="utf-8") as f:
+from setuptools import setup, find_packages
+
+with open(Path("docs", "dafni_cli.md"), encoding="utf-8") as f:
     long_description = f.read()
+
 # The dynamic metadata for the python pip distributable.
 # This is used as the build script for setuptools, telling it about the package and which files to include.
 # For more information, see https://packaging.python.org/tutorials/packaging-projects/

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os import path
 
 # TODO use pathlib
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "docs\\dafni_cli.md"), encoding="utf-8") as f:
+with open(path.join(this_directory, "docs", "dafni_cli.md"), encoding="utf-8") as f:
     long_description = f.read()
 # The dynamic metadata for the python pip distributable.
 # This is used as the build script for setuptools, telling it about the package and which files to include.


### PR DESCRIPTION
- Fixes incorrect path in setup.py preventing install on Linux (and presumably macOS) using pathlib #55
- Removes unused multimethod import that subsequently prevented the cli from running unless installed separately
- Updates README with the current status having gone through each command one by one (CORE-2920 & CORE-2936), also looked at latest https://github.com/NewcastleRSE/dafni-cli

Closes #55