### PR TITLE
Use pathlib for all paths and remove non-user params [CORE-2934 & CORE-2993]

### DIFF
--- a/dafni_cli/commands/download.py
+++ b/dafni_cli/commands/download.py
@@ -1,4 +1,5 @@
-import os
+from pathlib import Path
+import pathlib
 from typing import List, Optional
 
 import click
@@ -25,7 +26,7 @@ def download(ctx: Context):
 @download.command(help="Download all dataset files for given version")
 @click.option(
     "--directory",
-    type=click.Path(exists=True, dir_okay=True),
+    type=click.Path(exists=True, dir_okay=True, path_type=Path),
     help="Directory to save the zipped Dataset files to. Default is the current working directory",
 )
 @click.argument("dataset-id", nargs=1, required=True, type=str)
@@ -35,7 +36,7 @@ def dataset(
     ctx: Context,
     dataset_id: str,
     version_id: List[str],
-    directory: Optional[click.Path],
+    directory: Optional[Path],
 ):
     """Download all files associated with the given Dataset Version.
 
@@ -43,7 +44,7 @@ def dataset(
         ctx (Context): CLI context
         dataset_id (str): Dataset ID
         version_id (str): Dataset version ID
-        directory (Optional[click.Path]): Directory to write zip folder to
+        directory (Optional[Path]): Directory to write zip folder to
     """
     metadata = parse_dataset_metadata(
         get_latest_dataset_metadata(ctx.obj["session"], dataset_id, version_id)
@@ -55,14 +56,14 @@ def dataset(
 
         # Setup file paths
         if not directory:
-            directory = os.getcwd()
+            directory = Path.cwd()
         zip_name = f"Dataset_{dataset_id}_{version_id}.zip"
-        path = os.path.join(directory, zip_name)
+        path = directory / zip_name
         # Write files to disk
         write_files_to_zip(path, file_names, file_contents)
         # Output file details
         click.echo("\nThe dataset files have been downloaded to:")
-        click.echo(os.path.join(directory, zip_name))
+        click.echo(path)
         metadata.output_datafiles_table()
     else:
         click.echo(

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import List
 
 import click
@@ -37,8 +38,12 @@ def upload(ctx: Context):
 # COMMAND: Upload a MODEL to DAFNI
 ###############################################################################
 @upload.command(help="Upload a model to DAFNI")
-@click.argument("definition", nargs=1, required=True, type=click.Path(exists=True))
-@click.argument("image", nargs=1, required=True, type=click.Path(exists=True))
+@click.argument(
+    "definition", nargs=1, required=True, type=click.Path(exists=True, path_type=Path)
+)
+@click.argument(
+    "image", nargs=1, required=True, type=click.Path(exists=True, path_type=Path)
+)
 @click.option(
     "--version-message",
     "-m",
@@ -56,8 +61,8 @@ def upload(ctx: Context):
 @click.pass_context
 def model(
     ctx: Context,
-    definition: click.Path,
-    image: click.Path,
+    definition: Path,
+    image: Path,
     version_message: str,
     parent_id: str,
 ):
@@ -65,8 +70,8 @@ def model(
 
     Args:
         ctx (Context): contains user session for authentication
-        definition (click.Path): File path to the model definition file
-        image (click.Path): File path to the image file
+        definition (Path): File path to the model definition file
+        image (Path): File path to the image file
         version_message (str): Version message to be included with this model version
         parent_id (str): ID of the parent model that this is an update of
     """
@@ -114,16 +119,20 @@ def model(
 # COMMAND: Upload a DATASET to DAFNI
 ###############################################################################
 @upload.command(help="Upload a dataset to DAFNI")
-@click.argument("definition", nargs=1, required=True, type=click.Path(exists=True))
-@click.argument("files", nargs=-1, required=True, type=click.Path(exists=True))
+@click.argument(
+    "definition", nargs=1, required=True, type=click.Path(exists=True, path_type=Path)
+)
+@click.argument(
+    "files", nargs=-1, required=True, type=click.Path(exists=True, path_type=Path)
+)
 @click.pass_context
-def dataset(ctx: Context, definition: click.Path, files: List[click.Path]):
+def dataset(ctx: Context, definition: Path, files: List[Path]):
     """Uploads a Dataset to DAFNI from metadata and dataset files.
 
     Args:
         ctx (Context): contains user session for authentication
-        definition (click.Path): Dataset metadata file
-        files (List[click.Path]): Dataset data files
+        definition (Path): Dataset metadata file
+        files (List[Path]): Dataset data files
     """
     # Confirm upload details
     argument_names = ["Dataset definition file path"] + [
@@ -141,7 +150,9 @@ def dataset(ctx: Context, definition: click.Path, files: List[click.Path]):
 # COMMAND: Upload a WORKFLOW to DAFNI
 ###############################################################################
 @upload.command(help="Upload a workflow to DAFNI")
-@click.argument("definition", nargs=1, required=True, type=click.Path(exists=True))
+@click.argument(
+    "definition", nargs=1, required=True, type=click.Path(exists=True, path_type=Path)
+)
 @click.option(
     "--version-message",
     "-m",
@@ -162,7 +173,7 @@ def dataset(ctx: Context, definition: click.Path, files: List[click.Path]):
 @click.pass_context
 def workflow(
     ctx: Context,
-    definition: click.Path,
+    definition: Path,
     version_message: str,
     parent_id: str,
 ):
@@ -171,7 +182,7 @@ def workflow(
 
     Args:
         ctx (Context): contains user session for authentication
-        definition (click.Path): File path to the workflow definition file
+        definition (Path): File path to the workflow definition file
         version_message (str): Version message to be included with this workflow version
         parent_id (str): ID of the parent workflow that this is an update of
     """
@@ -202,8 +213,10 @@ def workflow(
 ###############################################################################
 # TODO - WIP
 @upload.command(help="Upload a parameterised workflow to DAFNI")
-@click.argument("definition", nargs=1, required=True, type=click.Path(exists=True))
-# @click.argument("image", nargs=1, required=True, type=click.Path(exists=True))
+@click.argument(
+    "definition", nargs=1, required=True, type=click.Path(exists=True, path_type=Path)
+)
+# @click.argument("image", nargs=1, required=True, type=click.Path(exists=True, path_type=Path))
 @click.option(
     "--version-message",
     "-m",
@@ -221,7 +234,7 @@ def workflow(
 @click.pass_context
 def workflow_params(
     ctx: Context,
-    definition: click.Path,
+    definition: Path,
     version_message: str,
     parent_id: str,
 ):
@@ -230,7 +243,7 @@ def workflow_params(
 
     Args:
         ctx (Context): contains user session for authentication
-        definition (click.Path): File path to the workflow definition file
+        definition (Path): File path to the workflow definition file
         version_message (str): Version message to be included with this model version
         parent_model (str): ID of the parent model that this is an update of
     """

--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -66,19 +66,16 @@ class Creator(ParserBaseObject):
         type (str): Creator type
         name (str): Creator name
         id (Optional[str]): Creator id
-        internal_id (Optional[str]): Internal id
     """
 
     type: str
     name: str
     id: Optional[str] = None
-    internal_id: Optional[str] = None
 
     _parser_params: ClassVar[List[ParserParam]] = [
         ParserParam("type", "@type", str),
         ParserParam("name", "foaf:name", str),
         ParserParam("id", "@id", str),
-        ParserParam("internal_id", "internalID", str),
     ]
 
 
@@ -136,19 +133,16 @@ class Publisher(ParserBaseObject):
         type (str or None): Publisher type
         id (str or None): Publisher id
         name (str or None): Publisher name
-        internal_id (str or None): Publisher internal id
     """
 
     type: str
     id: Optional[str] = None
     name: Optional[str] = None
-    internal_id: Optional[str] = None
 
     _parser_params: ClassVar[List[ParserParam]] = [
         ParserParam("type", "@type", str),
         ParserParam("id", "@id", str),
         ParserParam("name", "foaf:name", str),
-        ParserParam("internal_id", "internalID", str),
     ]
 
     def __str__(self) -> str:

--- a/dafni_cli/datasets/dataset_upload.py
+++ b/dafni_cli/datasets/dataset_upload.py
@@ -1,5 +1,5 @@
 import json
-from os.path import basename, normpath
+from pathlib import Path
 from typing import List
 
 import click
@@ -17,14 +17,14 @@ from dafni_cli.api.session import DAFNISession
 
 
 def upload_new_dataset_files(
-    session: DAFNISession, definition_path: click.Path, file_paths: List[click.Path]
+    session: DAFNISession, definition_path: Path, file_paths: List[Path]
 ) -> None:
     """Function to upload all files associated with a new Dataset
 
     Args:
         session (DAFNISession): User session
-        definition_path (click.Path): Path to Dataset metadata file
-        file_paths (List[click.Path]): List of Paths to dataset data files
+        definition_path (Path): Path to Dataset metadata file
+        file_paths (List[Path]): List of Paths to dataset data files
     """
 
     click.echo("\nRetrieving temporary bucket ID")
@@ -48,19 +48,17 @@ def upload_new_dataset_files(
     click.echo(f"Metadata ID: {details['metadataId']}")
 
 
-def upload_files(
-    session: DAFNISession, temp_bucket_id: str, file_paths: List[click.Path]
-):
+def upload_files(session: DAFNISession, temp_bucket_id: str, file_paths: List[Path]):
     """Function to upload all given files to a temporary bucket via the Minio
     API
 
     Args:
         session (DAFNISession): User session
         temp_bucket_id (str): Minio temporary bucket ID to upload files to
-        file_paths (List[click.Path]): List of Paths to dataset data files
+        file_paths (List[Path]): List of Paths to dataset data files
     """
     click.echo("Retrieving file upload URls")
-    file_names = {basename(normpath(file_path)): file_path for file_path in file_paths}
+    file_names = {file_path.name: file_path for file_path in file_paths}
     upload_urls = get_data_upload_urls(session, temp_bucket_id, list(file_names.keys()))
 
     click.echo("Uploading files")
@@ -69,7 +67,7 @@ def upload_files(
 
 
 def upload_metadata(
-    session: DAFNISession, definition_path: click.Path, temp_bucket_id: str
+    session: DAFNISession, definition_path: Path, temp_bucket_id: str
 ) -> dict:
     """Function to upload the Metadata to the Minio API, with the
     given Minio Temporary Upload ID
@@ -79,7 +77,7 @@ def upload_metadata(
 
     Args:
         session ([type]): User session
-        definition_path (click.Path): Path to Metadata file
+        definition_path (Path): Path to Metadata file
         temp_bucket_id (str): Minio Temporary Bucket ID
 
     Returns:

--- a/dafni_cli/model/model.py
+++ b/dafni_cli/model/model.py
@@ -140,9 +140,6 @@ class Model(ParserBaseObject):
         --------
         api_version (Optional[str]): Version of the DAFNI API used to retrieve
                                    the model data
-        container (Optional[str]): Name of the docker image the model should
-                                   be run in
-        container_version (Optional[str]): Version of the docker image
         type (Optional[str]): Type of DAFNI object ("model")
         spec (Optional[ModelSpec]): Model specification - includes the image
                                     url and its inputs
@@ -161,8 +158,6 @@ class Model(ParserBaseObject):
     ingest_completed_date: Optional[datetime] = None
 
     api_version: Optional[str] = None
-    container: Optional[str] = None
-    container_version: Optional[str] = None
     type: Optional[str] = None
     spec: Optional[ModelSpec] = None
 
@@ -192,8 +187,6 @@ class Model(ParserBaseObject):
         ParserParam("ingest_completed_date", "ingest_completed_date", parse_datetime),
         ParserParam("_metadata", "metadata", ModelMetadata),
         ParserParam("api_version", "api_version", str),
-        ParserParam("container", "container", str),
-        ParserParam("container_version", "container_version", str),
         ParserParam("type", "type", str),
         ParserParam("spec", "spec", ModelSpec),
         ParserParam("_display_name", "display_name", str),

--- a/dafni_cli/utils.py
+++ b/dafni_cli/utils.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 import textwrap
 from dataclasses import fields
 from datetime import datetime as dt
@@ -172,12 +173,12 @@ def argument_confirmation(
 
 
 def write_files_to_zip(
-    zip_path: str, file_names: List[str], file_contents: List[BytesIO]
+    zip_path: Path, file_names: List[str], file_contents: List[BytesIO]
 ) -> None:
     """Function to compress a list of files to a zip folder, and write to disk
 
     Args:
-        zip_path (str): Full path including file name to write to
+        zip_path (Path): Full path including file name to write to
         file_names (List[str]): List of all file names
         file_contents (List[BytesIO]): List of file contents, 1 for each name
     """

--- a/test/commands/test_download.py
+++ b/test/commands/test_download.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -52,9 +52,7 @@ class TestDownload(TestCase):
         version_id = "version-id"
         file_names = ["file_name1", "file_name2"]
         file_contents = ["file_contents1", "file_contents2"]
-        expected_download_path = os.path.join(
-            os.getcwd(), f"Dataset_{dataset_id}_{version_id}.zip"
-        )
+        expected_download_path = Path.cwd() / f"Dataset_{dataset_id}_{version_id}.zip"
         metadata = MagicMock()
         metadata.files = [MagicMock(), MagicMock()]
         metadata.download_dataset_files = MagicMock()
@@ -113,8 +111,8 @@ class TestDownload(TestCase):
         file_names = ["file_name1", "file_name2"]
         file_contents = [b"file_contents1", b"file_contents2"]
         directory = "some_folder"
-        expected_download_path = os.path.join(
-            directory, f"Dataset_{dataset_id}_{version_id}.zip"
+        expected_download_path = (
+            Path(directory) / f"Dataset_{dataset_id}_{version_id}.zip"
         )
         metadata = MagicMock()
         metadata.files = [MagicMock(), MagicMock()]
@@ -127,7 +125,7 @@ class TestDownload(TestCase):
 
         # CALL
         with runner.isolated_filesystem():
-            os.mkdir(directory)
+            Path(directory).mkdir()
 
             result = runner.invoke(
                 download.download,

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
 
@@ -89,7 +90,7 @@ class TestUpload(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_validate_model_definition.assert_called_once_with(
-            session, "test_definition.yaml"
+            session, Path("test_definition.yaml")
         )
         mock_get_model_upload_urls.assert_called_once_with(session)
         mock_upload_file_to_minio.assert_has_calls(
@@ -97,12 +98,12 @@ class TestUpload(TestCase):
                 call(
                     session,
                     TEST_MODELS_UPLOAD_RESPONSE["urls"]["definition"],
-                    "test_definition.yaml",
+                    Path("test_definition.yaml"),
                 ),
                 call(
                     session,
                     TEST_MODELS_UPLOAD_RESPONSE["urls"]["image"],
-                    "test_image.txt",
+                    Path("test_image.txt"),
                 ),
             ]
         )
@@ -173,7 +174,7 @@ class TestUpload(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_validate_model_definition.assert_called_once_with(
-            session, "test_definition.yaml"
+            session, Path("test_definition.yaml")
         )
         mock_get_model_upload_urls.assert_called_once_with(session)
         mock_upload_file_to_minio.assert_has_calls(
@@ -181,12 +182,12 @@ class TestUpload(TestCase):
                 call(
                     session,
                     TEST_MODELS_UPLOAD_RESPONSE["urls"]["definition"],
-                    "test_definition.yaml",
+                    Path("test_definition.yaml"),
                 ),
                 call(
                     session,
                     TEST_MODELS_UPLOAD_RESPONSE["urls"]["image"],
-                    "test_image.txt",
+                    Path("test_image.txt"),
                 ),
             ]
         )
@@ -258,7 +259,7 @@ class TestUpload(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_validate_model_definition.assert_called_once_with(
-            session, "test_definition.yaml"
+            session, Path("test_definition.yaml")
         )
 
         self.assertEqual(
@@ -371,7 +372,7 @@ class TestUpload(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_new_dataset_files.assert_called_once_with(
-            session, "test_definition.json", ("test_dataset.txt",)
+            session, Path("test_definition.json"), (Path("test_dataset.txt"),)
         )
 
         self.assertEqual(
@@ -418,7 +419,9 @@ class TestUpload(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_new_dataset_files.assert_called_once_with(
-            session, "test_definition.json", ("test_dataset1.txt", "test_dataset2.txt")
+            session,
+            Path("test_definition.json"),
+            (Path("test_dataset1.txt"), Path("test_dataset2.txt")),
         )
 
         self.assertEqual(
@@ -504,7 +507,7 @@ class TestUpload(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_workflow.assert_called_once_with(
-            session, "test_definition.json", None, None
+            session, Path("test_definition.json"), None, None
         )
 
         self.assertEqual(
@@ -552,7 +555,7 @@ class TestUpload(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_workflow.assert_called_once_with(
-            session, "test_definition.json", "version_message", "parent-id"
+            session, Path("test_definition.json"), "version_message", "parent-id"
         )
 
         self.assertEqual(

--- a/test/datasets/test_dataset_metadata.py
+++ b/test/datasets/test_dataset_metadata.py
@@ -95,9 +95,6 @@ class TestCreator(TestCase):
         self.assertEqual(creator.type, TEST_DATASET_METADATA_CREATOR["@type"])
         self.assertEqual(creator.name, TEST_DATASET_METADATA_CREATOR["foaf:name"])
         self.assertEqual(creator.id, TEST_DATASET_METADATA_CREATOR["@id"])
-        self.assertEqual(
-            creator.internal_id, TEST_DATASET_METADATA_CREATOR["internalID"]
-        )
 
     def test_parse_when_no_optional_values(self):
         """Tests parsing of creators with all values filled"""
@@ -110,7 +107,6 @@ class TestCreator(TestCase):
             creator.name, TEST_DATASET_METADATA_CREATOR_DEFAULT["foaf:name"]
         )
         self.assertEqual(creator.id, None)
-        self.assertEqual(creator.internal_id, None)
 
 
 class TestContact(TestCase):
@@ -153,9 +149,6 @@ class TestPublisher(TestCase):
         self.assertEqual(publisher.type, TEST_DATASET_METADATA_PUBLISHER["@type"])
         self.assertEqual(publisher.id, TEST_DATASET_METADATA_PUBLISHER["@id"])
         self.assertEqual(publisher.name, TEST_DATASET_METADATA_PUBLISHER["foaf:name"])
-        self.assertEqual(
-            publisher.internal_id, TEST_DATASET_METADATA_PUBLISHER["internalID"]
-        )
 
     def test_parse_when_no_optional_values(self):
         """Tests parsing of a publisher with optional values ignored"""
@@ -168,7 +161,6 @@ class TestPublisher(TestCase):
         )
         self.assertEqual(publisher.id, None)
         self.assertEqual(publisher.name, None)
-        self.assertEqual(publisher.internal_id, None)
 
 
 class TestStandard(TestCase):

--- a/test/datasets/test_dataset_upload.py
+++ b/test/datasets/test_dataset_upload.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, call, mock_open, patch
 
@@ -168,9 +169,11 @@ class TestDatasetUpload(TestCase):
         # SETUP
         session = MagicMock()
         temp_bucket_id = "some-temp-bucket"
-        file_paths = ["file_1.txt", "file_2.txt"]
-        urls = [f"upload/url/{file_name}" for file_name in file_paths]
-        upload_urls = {"URLs": {file_paths[idx]: url for idx, url in enumerate(urls)}}
+        file_paths = [Path("file_1.txt"), Path("file_2.txt")]
+        urls = [f"upload/url/{file_path.name}" for file_path in file_paths]
+        upload_urls = {
+            "URLs": {file_paths[idx].name: url for idx, url in enumerate(urls)}
+        }
 
         mock_get_data_upload_urls.return_value = upload_urls
 
@@ -179,7 +182,7 @@ class TestDatasetUpload(TestCase):
 
         # ASSERT
         mock_get_data_upload_urls.assert_called_once_with(
-            session, temp_bucket_id, file_paths
+            session, temp_bucket_id, [file_path.name for file_path in file_paths]
         )
         mock_upload_file_to_minio.assert_has_calls(
             [call(session, url, file_paths[idx]) for idx, url in enumerate(urls)]

--- a/test/model/test_models.py
+++ b/test/model/test_models.py
@@ -102,8 +102,6 @@ class TestModel(TestCase):
         )
 
         self.assertEqual(model1.api_version, None)
-        self.assertEqual(model1.container, None)
-        self.assertEqual(model1.container_version, None)
         self.assertEqual(model1.type, model1_dict["type"])
         self.assertEqual(model1.spec, None)
 
@@ -170,8 +168,6 @@ class TestModel(TestCase):
         )
 
         self.assertEqual(model.api_version, TEST_MODEL["api_version"])
-        self.assertEqual(model.container, TEST_MODEL["container"])
-        self.assertEqual(model.container_version, TEST_MODEL["container_version"])
         self.assertEqual(model.type, TEST_MODEL["type"])
 
         # Model spec (contents tested in TestModelSpec)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
-import os
 import tempfile
+from dataclasses import dataclass
 from io import BytesIO
+from pathlib import Path
 from typing import List, Optional
 from unittest import TestCase
 from unittest.mock import call, patch
@@ -574,7 +574,7 @@ class TestWriteFilesToZip(TestCase):
         with the correct contents"""
         # SETUP
         with tempfile.TemporaryDirectory() as temp_dir:
-            zip_path = os.path.join(temp_dir, "test.zip")
+            zip_path = Path(temp_dir, "test.zip")
 
             file_names = ["file_1.txt", "file_2.txt"]
             file_contents = [BytesIO(b"Test text 1"), BytesIO(b"Test text 2")]
@@ -583,7 +583,7 @@ class TestWriteFilesToZip(TestCase):
             utils.write_files_to_zip(zip_path, file_names, file_contents)
 
             # ASSERT
-            self.assertTrue(os.path.exists(zip_path))
+            self.assertTrue(zip_path.exists())
             with ZipFile(zip_path, "r") as zipObj:
                 self.assertEqual(zipObj.namelist(), file_names)
 


### PR DESCRIPTION
Replaces all instances of os.path methods with pathlib and modifies click arguments to use pathlib paths in command functions instead of strings.

Also removes non-user class params for [CORE-2993].