### PR TITLE
enhancement: Remove dataset_id from get and download commands [CORE-3051]

### DIFF
--- a/dafni_cli/api/datasets_api.py
+++ b/dafni_cli/api/datasets_api.py
@@ -23,15 +23,11 @@ def get_all_datasets(session: DAFNISession, filters: dict) -> List[dict]:
     return session.post_request(url=url, json=data, allow_redirect=True)
 
 
-# TODO: Make dataset_id optional? - Can search just by version ID now
-def get_latest_dataset_metadata(
-    session: DAFNISession, dataset_id: str, version_id: str
-) -> dict:
+def get_latest_dataset_metadata(session: DAFNISession, version_id: str) -> dict:
     """Function to get the dataset metadata for a given dataset
 
     Args:
         session (str): User session
-        dataset_id (str): Dataset ID
         version_id (str): Dataset Version ID
 
     Returns:
@@ -40,7 +36,7 @@ def get_latest_dataset_metadata(
     Raises:
         ResourceNotFoundError: If a dataset with the given id's wasn't found
     """
-    url = f"{DISCOVERY_API_URL}/metadata/{dataset_id}/{version_id}"
+    url = f"{DISCOVERY_API_URL}/metadata/{version_id}"
 
     try:
         return session.get_request(url=url, allow_redirect=True)
@@ -48,5 +44,5 @@ def get_latest_dataset_metadata(
         # When the endpoint isn't found it means a dataset with the given id's
         # wasn't found
         raise ResourceNotFoundError(
-            f"Unable to find a dataset with id '{dataset_id}' and version_id '{version_id}'"
+            f"Unable to find a dataset with version_id '{version_id}'"
         ) from err

--- a/dafni_cli/api/workflows_api.py
+++ b/dafni_cli/api/workflows_api.py
@@ -86,24 +86,6 @@ def upload_workflow(
         return session.post_request(url=url, json=workflow_description)
 
 
-# TODO rename so different names and see if used
-# def upload_workflow(jwt: str, workflow_description: dict) -> Tuple[str, dict]:
-#    """
-#    Uploads a DAFNI workflow specified in a dictionary to the platform
-#
-#    Args:
-#        jwt (str): JWT
-#        workflow_description: A dictionary containing the workflow
-#
-#    Returns:
-#        str: The ID for the upload
-#        dict: The urls for the definition and image with keys "definition" and "image", respectively.
-#    """
-#    url = WORKFLOWS_API_URL + "/workflows/upload/"
-#    print(workflow_description)
-#    return dafni_post_request(url, jwt, workflow_description)
-
-
 def delete_workflow(session: DAFNISession, version_id: str) -> Response:
     """
     Calls the workflows_delete endpoint

--- a/dafni_cli/commands/download.py
+++ b/dafni_cli/commands/download.py
@@ -28,12 +28,10 @@ def download(ctx: Context):
     type=click.Path(exists=True, dir_okay=True, path_type=Path),
     help="Directory to save the zipped Dataset files to. Default is the current working directory",
 )
-@click.argument("dataset-id", nargs=1, required=True, type=str)
 @click.argument("version-id", nargs=1, required=True, type=str)
 @click.pass_context
 def dataset(
     ctx: Context,
-    dataset_id: str,
     version_id: List[str],
     directory: Optional[Path],
 ):
@@ -41,12 +39,11 @@ def dataset(
 
     Args:
         ctx (Context): CLI context
-        dataset_id (str): Dataset ID
         version_id (str): Dataset version ID
         directory (Optional[Path]): Directory to write zip folder to
     """
     metadata = parse_dataset_metadata(
-        get_latest_dataset_metadata(ctx.obj["session"], dataset_id, version_id)
+        get_latest_dataset_metadata(ctx.obj["session"], version_id)
     )
 
     if len(metadata.files) > 0:
@@ -56,7 +53,7 @@ def dataset(
         # Setup file paths
         if not directory:
             directory = Path.cwd()
-        zip_name = f"Dataset_{dataset_id}_{version_id}.zip"
+        zip_name = f"Dataset_{metadata.dataset_id}_{version_id}.zip"
         path = directory / zip_name
         # Write files to disk
         write_files_to_zip(path, file_names, file_contents)

--- a/dafni_cli/commands/get.py
+++ b/dafni_cli/commands/get.py
@@ -220,12 +220,10 @@ def datasets(
     help="Prints raw json returned from API. Default: -p",
     type=bool,
 )
-@click.argument("id", nargs=1, required=True, type=str)
 @click.argument("version-id", nargs=1, required=True, type=str)
 @click.pass_context
 def dataset(
     ctx: Context,
-    id: str,
     version_id: str,
     long: bool,
     version_history: bool,
@@ -235,7 +233,6 @@ def dataset(
 
     Args:
         ctx (Context): CLI context
-        id (str): Dataset ID
         version_id (str): Dataset version ID
         long (bool): Flag to view additional metadata attributes
         version_history (bool): Flag to view version history in place of metadata
@@ -243,7 +240,7 @@ def dataset(
     """
     # Attempt to get the metadata
     try:
-        metadata = get_latest_dataset_metadata(ctx.obj["session"], id, version_id)
+        metadata = get_latest_dataset_metadata(ctx.obj["session"], version_id)
     except ResourceNotFoundError as err:
         raise SystemExit(err) from err
 

--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -259,9 +259,7 @@ class DatasetVersionHistory(ParserBaseObject):
         """
         json_list = []
         for version in self.versions:
-            metadata = get_latest_dataset_metadata(
-                session, self.dataset_id, version.version_id
-            )
+            metadata = get_latest_dataset_metadata(session, version.version_id)
             if json_flag:
                 json_list.append(metadata)
             else:

--- a/scripts/test_script.py
+++ b/scripts/test_script.py
@@ -107,7 +107,9 @@ COMMAND_PARAMS = (
 class DownloadDatasetCommand(SpecialCommand):
     """Command that downloads a dataset"""
 
-    BASE_COMMAND = f"dafni download dataset {COMMAND_PARAMS['datasets'][1]['id']} {COMMAND_PARAMS['datasets'][1]['version_id']}"
+    BASE_COMMAND = (
+        f"dafni download dataset {COMMAND_PARAMS['datasets'][1]['version_id']}"
+    )
 
     def __init__(self) -> None:
         super().__init__()
@@ -177,12 +179,12 @@ COMMANDS = {
         ],
         "dataset": [
             "dafni get dataset --help",
-            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['id']} {COMMAND_PARAMS['datasets'][0]['version_id']}",
-            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['id']} {COMMAND_PARAMS['datasets'][0]['version_id']} --long",
-            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['id']} {COMMAND_PARAMS['datasets'][0]['version_id']} -l",
-            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['id']} {COMMAND_PARAMS['datasets'][0]['version_id']} --version-history",
-            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['id']} {COMMAND_PARAMS['datasets'][0]['version_id']} --json",
-            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['id']} {COMMAND_PARAMS['datasets'][0]['version_id']} --version-history --json",
+            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['version_id']}",
+            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['version_id']} --long",
+            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['version_id']} -l",
+            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['version_id']} --version-history",
+            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['version_id']} --json",
+            f"dafni get dataset {COMMAND_PARAMS['datasets'][0]['version_id']} --version-history --json",
         ],
         "workflows": [
             "dafni get workflows --help",

--- a/test/api/test_datasets_api.py
+++ b/test/api/test_datasets_api.py
@@ -35,17 +35,14 @@ class TestDatasetsAPI(TestCase):
 
         # SETUP
         session = MagicMock()
-        dataset_id = "some-dataset-id"
         version_id = "some-version-id"
 
         # CALL
-        result = datasets_api.get_latest_dataset_metadata(
-            session, dataset_id, version_id
-        )
+        result = datasets_api.get_latest_dataset_metadata(session, version_id)
 
         # ASSERT
         session.get_request.assert_called_once_with(
-            url=f"{DISCOVERY_API_URL}/metadata/{dataset_id}/{version_id}",
+            url=f"{DISCOVERY_API_URL}/metadata/{version_id}",
             allow_redirect=True,
         )
         self.assertEqual(result, session.get_request.return_value)
@@ -56,7 +53,6 @@ class TestDatasetsAPI(TestCase):
 
         # SETUP
         session = MagicMock()
-        dataset_id = "some-dataset-id"
         version_id = "some-version-id"
         session.get_request.side_effect = EndpointNotFoundError(
             "Some 404 error message"
@@ -64,10 +60,10 @@ class TestDatasetsAPI(TestCase):
 
         # CALL
         with self.assertRaises(ResourceNotFoundError) as err:
-            datasets_api.get_latest_dataset_metadata(session, dataset_id, version_id)
+            datasets_api.get_latest_dataset_metadata(session, version_id)
 
         # ASSERT
         self.assertEqual(
             str(err.exception),
-            f"Unable to find a dataset with id '{dataset_id}' and version_id '{version_id}'",
+            f"Unable to find a dataset with version_id '{version_id}'",
         )

--- a/test/commands/test_download.py
+++ b/test/commands/test_download.py
@@ -29,9 +29,14 @@ class TestDownload(TestCase):
         self.assertEqual(ctx["session"], session)
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.download.get_latest_dataset_metadata")
-    @patch("dafni_cli.commands.download.parse_dataset_metadata")
-    @patch("dafni_cli.commands.download.write_files_to_zip")
+
+@patch("dafni_cli.commands.download.DAFNISession")
+@patch("dafni_cli.commands.download.get_latest_dataset_metadata")
+@patch("dafni_cli.commands.download.parse_dataset_metadata")
+@patch("dafni_cli.commands.download.write_files_to_zip")
+class TestDownloadDataset(TestCase):
+    """Test class to test the download dataset command"""
+
     def test_download_dataset(
         self,
         mock_write_files_to_zip,
@@ -87,9 +92,6 @@ class TestDownload(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.download.get_latest_dataset_metadata")
-    @patch("dafni_cli.commands.download.parse_dataset_metadata")
-    @patch("dafni_cli.commands.download.write_files_to_zip")
     def test_download_dataset_with_specific_directory(
         self,
         mock_write_files_to_zip,
@@ -152,10 +154,9 @@ class TestDownload(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.download.get_latest_dataset_metadata")
-    @patch("dafni_cli.commands.download.parse_dataset_metadata")
     def test_download_dataset_with_no_files(
         self,
+        mock_write_files_to_zip,
         mock_parse_dataset_metadata,
         mock_get_latest_dataset_metadata,
         mock_DAFNISession,
@@ -180,6 +181,7 @@ class TestDownload(TestCase):
         mock_parse_dataset_metadata.assert_called_once_with(
             mock_get_latest_dataset_metadata.return_value
         )
+        mock_write_files_to_zip.assert_not_called()
 
         self.assertEqual(
             result.output,

--- a/test/commands/test_download.py
+++ b/test/commands/test_download.py
@@ -21,9 +21,7 @@ class TestDownload(TestCase):
         ctx = {}
 
         # CALL
-        result = runner.invoke(
-            download.download, ["dataset", "dataset-id", "version-id"], obj=ctx
-        )
+        result = runner.invoke(download.download, ["dataset", "version-id"], obj=ctx)
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
@@ -48,28 +46,28 @@ class TestDownload(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
 
-        dataset_id = "dataset-id"
         version_id = "version-id"
         file_names = ["file_name1", "file_name2"]
         file_contents = ["file_contents1", "file_contents2"]
-        expected_download_path = Path.cwd() / f"Dataset_{dataset_id}_{version_id}.zip"
         metadata = MagicMock()
+        metadata.dataset_id = "dataset-id"
         metadata.files = [MagicMock(), MagicMock()]
         metadata.download_dataset_files = MagicMock()
         metadata.download_dataset_files.return_value = (
             file_names,
             file_contents,
         )
+        expected_download_path = (
+            Path.cwd() / f"Dataset_{metadata.dataset_id}_{version_id}.zip"
+        )
         mock_parse_dataset_metadata.return_value = metadata
 
         # CALL
-        result = runner.invoke(download.download, ["dataset", dataset_id, version_id])
+        result = runner.invoke(download.download, ["dataset", version_id])
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_id, version_id
-        )
+        mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
         mock_parse_dataset_metadata.assert_called_once_with(
             mock_get_latest_dataset_metadata.return_value
         )
@@ -106,20 +104,20 @@ class TestDownload(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
 
-        dataset_id = "dataset-id"
         version_id = "version-id"
         file_names = ["file_name1", "file_name2"]
         file_contents = [b"file_contents1", b"file_contents2"]
         directory = "some_folder"
-        expected_download_path = (
-            Path(directory) / f"Dataset_{dataset_id}_{version_id}.zip"
-        )
         metadata = MagicMock()
+        metadata.dataset_id = "dataset-id"
         metadata.files = [MagicMock(), MagicMock()]
         metadata.download_dataset_files = MagicMock()
         metadata.download_dataset_files.return_value = (
             file_names,
             file_contents,
+        )
+        expected_download_path = (
+            Path(directory) / f"Dataset_{metadata.dataset_id}_{version_id}.zip"
         )
         mock_parse_dataset_metadata.return_value = metadata
 
@@ -129,14 +127,12 @@ class TestDownload(TestCase):
 
             result = runner.invoke(
                 download.download,
-                ["dataset", dataset_id, version_id, "--directory", directory],
+                ["dataset", version_id, "--directory", directory],
             )
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_id, version_id
-        )
+        mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
         mock_parse_dataset_metadata.assert_called_once_with(
             mock_get_latest_dataset_metadata.return_value
         )
@@ -171,19 +167,16 @@ class TestDownload(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         metadata = MagicMock()
+        metadata.dataset_id = "dataset-id"
         metadata.files = []
         mock_parse_dataset_metadata.return_value = metadata
 
         # CALL
-        result = runner.invoke(
-            download.download, ["dataset", "dataset-id", "version-id"]
-        )
+        result = runner.invoke(download.download, ["dataset", "version-id"])
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_get_latest_dataset_metadata.assert_called_once_with(
-            session, "dataset-id", "version-id"
-        )
+        mock_get_latest_dataset_metadata.assert_called_once_with(session, "version-id")
         mock_parse_dataset_metadata.assert_called_once_with(
             mock_get_latest_dataset_metadata.return_value
         )

--- a/test/commands/test_get.py
+++ b/test/commands/test_get.py
@@ -624,13 +624,11 @@ class TestGet(TestCase):
         mock_parse_dataset_metadata.return_value = dataset
 
         # CALL
-        result = runner.invoke(get.get, ["dataset", "some_id", "some_version_id"])
+        result = runner.invoke(get.get, ["dataset", "some_version_id"])
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_get_latest_dataset_metadata.assert_called_with(
-            session, "some_id", "some_version_id"
-        )
+        mock_get_latest_dataset_metadata.assert_called_with(session, "some_version_id")
         dataset.output_metadata_details.assert_called_once()
         mock_print_json.assert_not_called()
 
@@ -657,15 +655,11 @@ class TestGet(TestCase):
         mock_parse_dataset_metadata.return_value = dataset
 
         # CALL
-        result = runner.invoke(
-            get.get, ["dataset", "some_id", "some_version_id", "--json"]
-        )
+        result = runner.invoke(get.get, ["dataset", "some_version_id", "--json"])
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_get_latest_dataset_metadata.assert_called_with(
-            session, "some_id", "some_version_id"
-        )
+        mock_get_latest_dataset_metadata.assert_called_with(session, "some_version_id")
         dataset.output_metadata_details.assert_not_called()
         mock_print_json.assert_called_once_with(dataset)
 
@@ -695,14 +689,12 @@ class TestGet(TestCase):
 
         # CALL
         result = runner.invoke(
-            get.get, ["dataset", "some_id", "some_version_id", "--version-history"]
+            get.get, ["dataset", "some_version_id", "--version-history"]
         )
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_get_latest_dataset_metadata.assert_called_with(
-            session, "some_id", "some_version_id"
-        )
+        mock_get_latest_dataset_metadata.assert_called_with(session, "some_version_id")
         dataset.version_history.process_and_output_version_history.assert_called_once_with(
             session, False
         )
@@ -735,14 +727,12 @@ class TestGet(TestCase):
         # CALL
         result = runner.invoke(
             get.get,
-            ["dataset", "some_id", "some_version_id", "--version-history", "--json"],
+            ["dataset", "some_version_id", "--version-history", "--json"],
         )
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_get_latest_dataset_metadata.assert_called_with(
-            session, "some_id", "some_version_id"
-        )
+        mock_get_latest_dataset_metadata.assert_called_with(session, "some_version_id")
         dataset.version_history.process_and_output_version_history.assert_called_once_with(
             session, True
         )

--- a/test/commands/test_get.py
+++ b/test/commands/test_get.py
@@ -27,11 +27,14 @@ class TestGet(TestCase):
         self.assertEqual(ctx["session"], session)
         self.assertEqual(result.exit_code, 0)
 
-    # ----------------- MODELS
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
+@patch("dafni_cli.commands.get.DAFNISession")
+@patch("dafni_cli.commands.get.get_all_models")
+@patch("dafni_cli.commands.get.parse_models")
+@patch("dafni_cli.commands.get.print_json")
+class TestGetModels(TestCase):
+    """Test class to test the get models command"""
+
     def test_get_models(
         self, mock_print_json, mock_parse_models, mock_get_all_models, mock_DAFNISession
     ):
@@ -58,9 +61,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_long_true(
         self, mock_print_json, mock_parse_models, mock_get_all_models, mock_DAFNISession
     ):
@@ -87,9 +87,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_json_true(
         self, mock_print_json, mock_parse_models, mock_get_all_models, mock_DAFNISession
     ):
@@ -158,9 +155,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_creation_date_filter(
         self,
         mock_print_json,
@@ -180,9 +174,6 @@ class TestGet(TestCase):
             False,
         )
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_publication_date_filter(
         self,
         mock_print_json,
@@ -202,9 +193,6 @@ class TestGet(TestCase):
             False,
         )
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_creation_date_filter_and_long_true(
         self,
         mock_print_json,
@@ -224,9 +212,6 @@ class TestGet(TestCase):
             True,
         )
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_publication_date_filter_and_long_true(
         self,
         mock_print_json,
@@ -285,9 +270,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_creation_date_filter_json(
         self,
         mock_print_json,
@@ -306,9 +288,6 @@ class TestGet(TestCase):
             ("--creation-date", "creation"),
         )
 
-    @patch("dafni_cli.commands.get.get_all_models")
-    @patch("dafni_cli.commands.get.parse_models")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_models_with_publication_date_filter_json(
         self,
         mock_print_json,
@@ -327,11 +306,17 @@ class TestGet(TestCase):
             ("--publication-date", "publication"),
         )
 
-    # ----------------- MODEL
 
-    @patch("dafni_cli.commands.get.get_model")
-    @patch("dafni_cli.commands.get.parse_model")
-    def test_get_model(self, mock_parse_model, mock_get_model, mock_DAFNISession):
+@patch("dafni_cli.commands.get.DAFNISession")
+@patch("dafni_cli.commands.get.get_model")
+@patch("dafni_cli.commands.get.parse_model")
+@patch("dafni_cli.commands.get.print_json")
+class TestGetModel(TestCase):
+    """Test class to test the get model command"""
+
+    def test_get_model(
+        self, mock_print_json, mock_parse_model, mock_get_model, mock_DAFNISession
+    ):
         """Tests that the 'get model' command works correctly (with no
         optional arguments)"""
 
@@ -350,12 +335,10 @@ class TestGet(TestCase):
         mock_DAFNISession.assert_called_once()
         mock_get_model.assert_called_with(session, "some_version_id")
         model.output_info.assert_called_once()
+        mock_print_json.assert_not_called()
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_model")
-    @patch("dafni_cli.commands.get.parse_model")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_model_json(
         self, mock_print_json, mock_parse_model, mock_get_model, mock_DAFNISession
     ):
@@ -380,9 +363,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_model")
-    @patch("dafni_cli.commands.get.parse_model")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_model_version_history(
         self, mock_print_json, mock_parse_model, mock_get_model, mock_DAFNISession
     ):
@@ -410,9 +390,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_model")
-    @patch("dafni_cli.commands.get.parse_model")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_model_version_history_json(
         self, mock_print_json, mock_parse_model, mock_get_model, mock_DAFNISession
     ):
@@ -441,11 +418,14 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    # ----------------- DATASETS
 
-    @patch("dafni_cli.commands.get.get_all_datasets")
-    @patch("dafni_cli.commands.get.parse_datasets")
-    @patch("dafni_cli.commands.get.print_json")
+@patch("dafni_cli.commands.get.DAFNISession")
+@patch("dafni_cli.commands.get.get_all_datasets")
+@patch("dafni_cli.commands.get.parse_datasets")
+@patch("dafni_cli.commands.get.print_json")
+class TestGetDatasets(TestCase):
+    """Test class to test the get datasets command"""
+
     def test_get_datasets(
         self,
         mock_print_json,
@@ -476,9 +456,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_datasets")
-    @patch("dafni_cli.commands.get.parse_datasets")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_datasets_with_json_true(
         self,
         mock_print_json,
@@ -542,9 +519,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_datasets")
-    @patch("dafni_cli.commands.get.parse_datasets")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_datasets_with_start_date_filter(
         self,
         mock_print_json,
@@ -571,9 +545,6 @@ class TestGet(TestCase):
             ),
         )
 
-    @patch("dafni_cli.commands.get.get_all_datasets")
-    @patch("dafni_cli.commands.get.parse_datasets")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_datasets_with_end_date_filter(
         self,
         mock_print_json,
@@ -600,11 +571,14 @@ class TestGet(TestCase):
             ),
         )
 
-    # ----------------- DATASET
 
-    @patch("dafni_cli.commands.get.get_latest_dataset_metadata")
-    @patch("dafni_cli.commands.get.parse_dataset_metadata")
-    @patch("dafni_cli.commands.get.print_json")
+@patch("dafni_cli.commands.get.DAFNISession")
+@patch("dafni_cli.commands.get.get_latest_dataset_metadata")
+@patch("dafni_cli.commands.get.parse_dataset_metadata")
+@patch("dafni_cli.commands.get.print_json")
+class TestGetDataset(TestCase):
+    """Test class to test the get dataset command"""
+
     def test_get_dataset(
         self,
         mock_print_json,
@@ -634,9 +608,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_latest_dataset_metadata")
-    @patch("dafni_cli.commands.get.parse_dataset_metadata")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_dataset_json(
         self,
         mock_print_json,
@@ -665,9 +636,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_latest_dataset_metadata")
-    @patch("dafni_cli.commands.get.parse_dataset_metadata")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_dataset_version_history(
         self,
         mock_print_json,
@@ -702,9 +670,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_latest_dataset_metadata")
-    @patch("dafni_cli.commands.get.parse_dataset_metadata")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_dataset_version_history_json(
         self,
         mock_print_json,
@@ -740,11 +705,14 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    # ----------------- WORKFLOWS
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
+@patch("dafni_cli.commands.get.DAFNISession")
+@patch("dafni_cli.commands.get.get_all_workflows")
+@patch("dafni_cli.commands.get.parse_workflows")
+@patch("dafni_cli.commands.get.print_json")
+class TestGetWorkflows(TestCase):
+    """Test class to test the get workflows command"""
+
     def test_get_workflows(
         self,
         mock_print_json,
@@ -775,9 +743,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_long_true(
         self,
         mock_print_json,
@@ -808,9 +773,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_json_true(
         self,
         mock_print_json,
@@ -882,9 +844,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_creation_date_filter(
         self,
         mock_print_json,
@@ -904,9 +863,6 @@ class TestGet(TestCase):
             False,
         )
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_publication_date_filter(
         self,
         mock_print_json,
@@ -926,9 +882,6 @@ class TestGet(TestCase):
             False,
         )
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_creation_date_filter_and_long_true(
         self,
         mock_print_json,
@@ -948,9 +901,6 @@ class TestGet(TestCase):
             True,
         )
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_publication_date_filter_and_long_true(
         self,
         mock_print_json,
@@ -1008,9 +958,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_creation_date_filter_json(
         self,
         mock_print_json,
@@ -1029,9 +976,6 @@ class TestGet(TestCase):
             ("--creation-date", "creation"),
         )
 
-    @patch("dafni_cli.commands.get.get_all_workflows")
-    @patch("dafni_cli.commands.get.parse_workflows")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflows_with_publication_date_filter_json(
         self,
         mock_print_json,
@@ -1050,11 +994,14 @@ class TestGet(TestCase):
             ("--publication-date", "publication"),
         )
 
-    # ----------------- WORKFLOW
 
-    @patch("dafni_cli.commands.get.get_workflow")
-    @patch("dafni_cli.commands.get.parse_workflow")
-    @patch("dafni_cli.commands.get.print_json")
+@patch("dafni_cli.commands.get.DAFNISession")
+@patch("dafni_cli.commands.get.get_workflow")
+@patch("dafni_cli.commands.get.parse_workflow")
+@patch("dafni_cli.commands.get.print_json")
+class TestGetWorkflow(TestCase):
+    """Test class to test the get workflow command"""
+
     def test_get_workflow(
         self, mock_print_json, mock_parse_workflow, mock_get_workflow, mock_DAFNISession
     ):
@@ -1080,9 +1027,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_workflow")
-    @patch("dafni_cli.commands.get.parse_workflow")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflow_json(
         self, mock_print_json, mock_parse_workflow, mock_get_workflow, mock_DAFNISession
     ):
@@ -1107,9 +1051,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_workflow")
-    @patch("dafni_cli.commands.get.parse_workflow")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflow_version_history(
         self, mock_print_json, mock_parse_workflow, mock_get_workflow, mock_DAFNISession
     ):
@@ -1137,9 +1078,6 @@ class TestGet(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    @patch("dafni_cli.commands.get.get_workflow")
-    @patch("dafni_cli.commands.get.parse_workflow")
-    @patch("dafni_cli.commands.get.print_json")
     def test_get_workflow_version_history_json(
         self, mock_print_json, mock_parse_workflow, mock_get_workflow, mock_DAFNISession
     ):

--- a/test/datasets/test_dataset_metadata.py
+++ b/test/datasets/test_dataset_metadata.py
@@ -296,10 +296,7 @@ class TestDatasetVersionHistory(TestCase):
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_has_calls(
-            [
-                call(session, version_history.dataset_id, version.version_id)
-                for version in version_history.versions
-            ]
+            [call(session, version.version_id) for version in version_history.versions]
         )
         self.assertEqual(
             mock_output_version_details.call_count, len(version_history.versions)
@@ -332,10 +329,7 @@ class TestDatasetVersionHistory(TestCase):
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_has_calls(
-            [
-                call(session, version_history.dataset_id, version.version_id)
-                for version in version_history.versions
-            ]
+            [call(session, version.version_id) for version in version_history.versions]
         )
         self.assertEqual(mock_output_version_details.call_count, 0)
 


### PR DESCRIPTION
Removes dataset_id from 'get' and 'download' commands as version_id is sufficient. This is also more consistent with models and datasets and allows any default datasets listed in the outputs of get model to be looked up using the cli.

Also reorganised the get and download command tests to remove some repeated patching.