### PR TITLE
feat: Add ability to update a dataset's metadata [CORE-2731]

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Datasets:
 * View specific historical dataset version metadata (format as specific datasets latest metadata) - DONE
 * Download dataset data and metadata - BROKEN (fixed in https://github.com/NewcastleRSE/dafni-cli, is dataset zip only - metadata accessed separately)
 * Upload a new dataset - DONE (But not clear how to define the json definition file)
-* Update dataset metadata
+* Update dataset metadata - DONE
 * Update dataset data files to create new version - DONE
 
 Deleting models and datasets

--- a/dafni_cli/api/datasets_api.py
+++ b/dafni_cli/api/datasets_api.py
@@ -1,8 +1,10 @@
-from typing import List
+from typing import List, Optional
+
+import requests
 
 from dafni_cli.api.exceptions import EndpointNotFoundError, ResourceNotFoundError
 from dafni_cli.api.session import DAFNISession
-from dafni_cli.consts import SEARCH_AND_DISCOVERY_API_URL
+from dafni_cli.consts import NID_API_URL, SEARCH_AND_DISCOVERY_API_URL
 
 
 # TODO this should work with pagination - check
@@ -46,3 +48,68 @@ def get_latest_dataset_metadata(session: DAFNISession, version_id: str) -> dict:
         raise ResourceNotFoundError(
             f"Unable to find a dataset with version_id '{version_id}'"
         ) from err
+
+
+def upload_dataset_metadata(
+    session: DAFNISession,
+    temp_bucket_id: str,
+    metadata: dict,
+    dataset_id: Optional[str] = None,
+) -> requests.Response:
+    """Uploads dataset metadata to the NID
+
+    This will commit the dataset and triggers the deletion of the temporary
+    bucket when successful.
+
+    Args:
+        session (DAFNISession): User session
+        temp_bucket_id (str): Minio temporary bucket ID
+        metadata (dict): Dataset metadata
+        dataset_id (Optional[str]): Dataset ID if uploading a new version of
+                                    an existing dataset (Default: None)
+
+    Raises:
+        EndpointNotFoundError: If the post request returns a 404 status
+                               code
+        DAFNIError: If an error occurs with an error message from DAFNI
+        HTTPError: If any other error occurs without an error message from
+                   DAFNI
+
+    Returns:
+        Response: Upload Response
+    """
+    if dataset_id:
+        url = f"{NID_API_URL}/nid/dataset/{dataset_id}"
+    else:
+        url = f"{NID_API_URL}/nid/dataset/"
+    data = {"bucketId": temp_bucket_id, "metadata": metadata}
+    return session.post_request(url=url, json=data)
+
+
+def upload_dataset_metadata_version(
+    session: DAFNISession,
+    dataset_id: str,
+    version_id: str,
+    metadata: dict,
+) -> requests.Response:
+    """Uploads a new version of a dataset's metadata to the NID
+
+    Args:
+        session (DAFNISession): User session
+        dataset_id (str): Dataset ID
+        version_id (str): Dataset version ID
+        metadata (dict): Dataset metadata
+
+    Raises:
+        EndpointNotFoundError: If the post request returns a 404 status
+                               code
+        DAFNIError: If an error occurs with an error message from DAFNI
+        HTTPError: If any other error occurs without an error message from
+                   DAFNI
+
+    Returns:
+        Response: Upload Response
+    """
+    url = f"{NID_API_URL}/nid/metadata/{dataset_id}/{version_id}"
+    data = {"metadata": metadata}
+    return session.post_request(url=url, json=data)

--- a/dafni_cli/api/minio_api.py
+++ b/dafni_cli/api/minio_api.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Union
 
 import requests
 
@@ -84,42 +84,6 @@ def get_data_upload_urls(
     data = {"bucketId": temp_bucket_id, "datafiles": file_names}
 
     return session.patch_request(url=url, json=data, allow_redirect=True)
-
-
-def upload_dataset_metadata(
-    session: DAFNISession,
-    temp_bucket_id: str,
-    metadata: dict,
-    dataset_id: Optional[str] = None,
-) -> requests.Response:
-    """Uploads dataset metadata to Minio
-
-    This will commit the dataset and triggers the deletion of the temporary
-    bucket when successful.
-
-    Args:
-        session (DAFNISession): User session
-        temp_bucket_id (str): Minio Temporary Upload ID
-        metadata (dict): Dataset Metadata
-        dataset_id (Optional[str]): Dataset ID if uploading a new version of
-                                    an existing dataset (Default: None)
-
-    Raises:
-        EndpointNotFoundError: If the post request returns a 404 status
-                               code
-        DAFNIError: If an error occurs with an error message from DAFNI
-        HTTPError: If any other error occurs without an error message from
-                   DAFNI
-
-    Returns:
-        Response: Upload Response
-    """
-    if dataset_id:
-        url = f"{NID_API_URL}/nid/dataset/{dataset_id}"
-    else:
-        url = f"{NID_API_URL}/nid/dataset/"
-    data = {"bucketId": temp_bucket_id, "metadata": metadata}
-    return session.post_request(url=url, json=data)
 
 
 def minio_get_request(

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -135,8 +135,8 @@ def dataset(ctx: Context, definition: Path, files: List[Path]):
     with open(definition, "r", encoding="utf-8") as definition_file:
         metadata = json.load(definition_file)
 
-        # Upload the dataset
-        upload_dataset(ctx.obj["session"], metadata, files)
+    # Upload the dataset
+    upload_dataset(ctx.obj["session"], metadata, files)
 
 
 ###############################################################################

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -153,13 +153,13 @@ def dataset(ctx: Context, definition: Path, files: List[Path]):
 @click.option(
     "--definition",
     type=click.Path(exists=True, path_type=Path),
-    help="Path to a dataset metadata definition file to upload",
+    help="Path to a dataset metadata definition file to upload.",
 )
 @click.option(
     "--version-message",
     type=str,
     default=None,
-    help="Version message to replace in any existing or provided metadata",
+    help="Version message to replace in any existing or provided metadata.",
 )
 @click.option(
     "--save",
@@ -240,13 +240,13 @@ def dataset_version(
 @click.option(
     "--definition",
     type=click.Path(exists=True, path_type=Path),
-    help="Path to a dataset metadata definition file to upload",
+    help="Path to a dataset metadata definition file to upload.",
 )
 @click.option(
     "--version-message",
     type=str,
     default=None,
-    help="Version message to replace in any existing or provided metadata",
+    help="Version message to replace in any existing or provided metadata.",
 )
 @click.option(
     "--save",

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -104,7 +104,7 @@ def model(
 ###############################################################################
 @upload.command(help="Upload a new dataset to DAFNI")
 @click.argument(
-    "definition",
+    "metadata_path",
     nargs=1,
     required=True,
     type=click.Path(exists=True, path_type=Path),
@@ -116,24 +116,24 @@ def model(
     type=click.Path(exists=True, path_type=Path),
 )
 @click.pass_context
-def dataset(ctx: Context, definition: Path, files: List[Path]):
+def dataset(ctx: Context, metadata_path: Path, files: List[Path]):
     """Uploads a new Dataset to DAFNI from metadata and dataset files.
 
     Args:
         ctx (Context): contains user session for authentication
-        definition (Path): Dataset metadata file
+        metadata_path (Path): Dataset metadata file path
         files (List[Path]): Dataset data files
     """
     # Confirm upload details
-    arguments = [("Dataset definition file path", definition)] + [
+    arguments = [("Dataset metadata file path", metadata_path)] + [
         ("Dataset file path", file) for file in files
     ]
     confirmation_message = "Confirm dataset upload?"
     argument_confirmation(arguments, confirmation_message)
 
     # Obtain the metadata
-    with open(definition, "r", encoding="utf-8") as definition_file:
-        metadata = json.load(definition_file)
+    with open(metadata_path, "r", encoding="utf-8") as metadata_file:
+        metadata = json.load(metadata_file)
 
     # Upload the dataset
     upload_dataset(ctx.obj["session"], metadata, files)
@@ -151,9 +151,9 @@ def dataset(ctx: Context, definition: Path, files: List[Path]):
     type=click.Path(exists=True, path_type=Path),
 )
 @click.option(
-    "--definition",
+    "--metadata",
     type=click.Path(exists=True, path_type=Path),
-    help="Path to a dataset metadata definition file to upload.",
+    help="Path to a dataset metadata file to upload.",
 )
 @click.option(
     "--version-message",
@@ -172,7 +172,7 @@ def dataset_version(
     ctx: Context,
     existing_version_id: str,
     files: List[Path],
-    definition: Optional[Path],
+    metadata: Optional[Path],
     version_message: Optional[str],
     save: Optional[Path],
 ):
@@ -183,7 +183,7 @@ def dataset_version(
         existing_version_id (str): Existing version id of the dataset to add a
                                    new version to
         files (List[Path]): Dataset data files
-        definition (Optional[Path]): Dataset metadata file
+        metadata (Optional[Path]): Dataset metadata file
         version_message (Optional[str]): Version message
         save (Optional[Path]): Path to save existing metadata in for editing
     """
@@ -200,7 +200,7 @@ def dataset_version(
     # Load/modify the existing metdata according to the user input
     dataset_metadata_dict = modify_dataset_metadata_for_upload(
         existing_metadata=dataset_metadata_dict,
-        definition_path=definition,
+        metadata_path=metadata,
         version_message=version_message,
     )
 
@@ -217,8 +217,8 @@ def dataset_version(
             ("Dataset Version ID", dataset_metadata_obj.version_id),
         ] + [("Dataset file path", file) for file in files]
 
-        if definition:
-            arguments.append(("Dataset definition file path", definition))
+        if metadata:
+            arguments.append(("Dataset metadata file path", metadata))
 
         confirmation_message = "Confirm dataset upload?"
         argument_confirmation(arguments, confirmation_message)
@@ -238,9 +238,9 @@ def dataset_version(
 @upload.command(help="Upload a new version of a dataset's metadata to DAFNI")
 @click.argument("existing_version_id", required=True, type=str)
 @click.option(
-    "--definition",
+    "--metadata",
     type=click.Path(exists=True, path_type=Path),
-    help="Path to a dataset metadata definition file to upload.",
+    help="Path to a dataset metadata file to upload.",
 )
 @click.option(
     "--version-message",
@@ -258,7 +258,7 @@ def dataset_version(
 def dataset_metadata(
     ctx: Context,
     existing_version_id: str,
-    definition: Optional[Path],
+    metadata: Optional[Path],
     version_message: Optional[str],
     save: Optional[Path],
 ):
@@ -268,7 +268,7 @@ def dataset_metadata(
         ctx (Context): contains user session for authentication
         existing_version_id (str): Existing version id of the dataset to add a
                                    new version to
-        definition (Optional[Path]): Dataset metadata file
+        metadata (Optional[Path]): Dataset metadata file
         version_message (Optional[str]): Version message
         save (Optional[Path]): Path to save existing metadata in for editing
     """
@@ -285,7 +285,7 @@ def dataset_metadata(
     # Load/modify the existing metdata according to the user input
     dataset_metadata_dict = modify_dataset_metadata_for_upload(
         existing_metadata=dataset_metadata_dict,
-        definition_path=definition,
+        metadata_path=metadata,
         version_message=version_message,
     )
 
@@ -302,8 +302,8 @@ def dataset_metadata(
             ("Dataset Version ID", dataset_metadata_obj.version_id),
         ]
 
-        if definition:
-            arguments.append(("Dataset definition file path", definition))
+        if metadata:
+            arguments.append(("Dataset metadata file path", metadata))
 
         confirmation_message = "Confirm metadata upload?"
         argument_confirmation(arguments, confirmation_message)

--- a/dafni_cli/datasets/dataset_upload.py
+++ b/dafni_cli/datasets/dataset_upload.py
@@ -176,7 +176,7 @@ def upload_dataset_metadata_version(
     version_id: str,
     metadata: dict,
 ) -> None:
-    """Function to upload a Dataset
+    """Function to upload a new metadata version to an existing dataset
 
     Args:
         session (DAFNISession): User session

--- a/dafni_cli/datasets/dataset_upload.py
+++ b/dafni_cli/datasets/dataset_upload.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import click
 from requests.exceptions import HTTPError
 
-from dafni_cli.api.datasets_api import upload_dataset_metadata
+import dafni_cli.api.datasets_api as datasets_api
 from dafni_cli.api.exceptions import DAFNIError, EndpointNotFoundError
 from dafni_cli.api.minio_api import (
     create_temp_bucket,
@@ -121,7 +121,7 @@ def _commit_metadata(
     """
     click.echo("Uploading metadata file")
     try:
-        response = upload_dataset_metadata(
+        response = datasets_api.upload_dataset_metadata(
             session, temp_bucket_id, metadata, dataset_id=dataset_id
         )
     except (EndpointNotFoundError, DAFNIError, HTTPError) as err:
@@ -163,6 +163,35 @@ def upload_dataset(
         click.echo("Deleting temporary bucket")
         delete_temp_bucket(session, temp_bucket_id)
         raise
+
+    # Output Details
+    click.echo("\nUpload successful")
+    click.echo(f"Dataset ID: {details['datasetId']}")
+    click.echo(f"Version ID: {details['versionId']}")
+    click.echo(f"Metadata ID: {details['metadataId']}")
+
+
+def upload_dataset_metadata_version(
+    session: DAFNISession,
+    dataset_id: str,
+    version_id: str,
+    metadata: dict,
+) -> None:
+    """Function to upload a Dataset
+
+    Args:
+        session (DAFNISession): User session
+        dataset_id (str): ID of an existing dataset to add the new metadata
+                          version to
+        version_id (str): Version ID fo an existing dataset to add the new
+                          metadata version to
+        metadata (dict): Metadata to upload
+
+    """
+
+    details = datasets_api.upload_dataset_metadata_version(
+        session, dataset_id=dataset_id, version_id=version_id, metadata=metadata
+    )
 
     # Output Details
     click.echo("\nUpload successful")

--- a/dafni_cli/datasets/dataset_upload.py
+++ b/dafni_cli/datasets/dataset_upload.py
@@ -44,7 +44,7 @@ def remove_dataset_metadata_invalid_for_upload(metadata: dict):
 
 def modify_dataset_metadata_for_upload(
     existing_metadata: dict,
-    definition_path: Optional[Path],
+    metadata_path: Optional[Path],
     version_message: Optional[str],
 ) -> dict:
     """Modifies existing dataset metadata or that loaded from a file according
@@ -52,7 +52,7 @@ def modify_dataset_metadata_for_upload(
 
     Args:
         existing_metadata (dict): Dictionary of existing metadata from the API
-        definition_path (Optional[Path]): Path to a Dataset metadata file.
+        metadata_path (Optional[Path]): Path to a Dataset metadata file.
                         When None will use the existing_metadata instead but
                         will delete any keys invalid for upload.
         version_message (Optional[str]): Version message - Will replace
@@ -61,11 +61,10 @@ def modify_dataset_metadata_for_upload(
         dict: The modified dataset metadata
     """
 
-    # Load the metadata from the definition file if present, or otherwise
-    # use the existing
-    if definition_path:
-        with open(definition_path, "r", encoding="utf-8") as definition_file:
-            metadata = json.load(definition_file)
+    # Load the metadata from a file if present, or otherwise use the existing
+    if metadata_path:
+        with open(metadata_path, "r", encoding="utf-8") as metadata_file:
+            metadata = json.load(metadata_file)
     else:
         metadata = deepcopy(existing_metadata)
 

--- a/dafni_cli/datasets/dataset_upload.py
+++ b/dafni_cli/datasets/dataset_upload.py
@@ -6,12 +6,12 @@ from typing import List, Optional
 import click
 from requests.exceptions import HTTPError
 
+from dafni_cli.api.datasets_api import upload_dataset_metadata
 from dafni_cli.api.exceptions import DAFNIError, EndpointNotFoundError
 from dafni_cli.api.minio_api import (
     create_temp_bucket,
     delete_temp_bucket,
     get_data_upload_urls,
-    upload_dataset_metadata,
     upload_file_to_minio,
 )
 from dafni_cli.api.session import DAFNISession
@@ -98,14 +98,14 @@ def upload_files(session: DAFNISession, temp_bucket_id: str, file_paths: List[Pa
         upload_file_to_minio(session, value, file_names[key])
 
 
-def upload_metadata(
+def _commit_metadata(
     session: DAFNISession,
     metadata: dict,
     temp_bucket_id: str,
     dataset_id: Optional[str] = None,
 ) -> dict:
-    """Function to upload the Metadata to the Minio API, with the
-    given Minio Temporary Upload ID
+    """Function to upload the metadata to the NID API and
+    commit the dataset
 
     Deletes the temporary upload bucket if unsuccessful to avoid
     any unnecessary build up
@@ -156,7 +156,7 @@ def upload_dataset(
     try:
         # Upload all files
         upload_files(session, temp_bucket_id, file_paths)
-        details = upload_metadata(
+        details = _commit_metadata(
             session, metadata, temp_bucket_id, dataset_id=dataset_id
         )
     except BaseException:

--- a/dafni_cli/utils.py
+++ b/dafni_cli/utils.py
@@ -12,8 +12,6 @@ import click
 from tabulate import tabulate
 
 from dafni_cli.consts import (
-    DATE_INPUT_FORMAT,
-    DATE_INPUT_FORMAT_VERBOSE,
     DATE_OUTPUT_FORMAT,
     DATE_TIME_OUTPUT_FORMAT,
     TABULATE_ARGS,

--- a/scripts/test_script.py
+++ b/scripts/test_script.py
@@ -227,6 +227,10 @@ COMMANDS = {
             "dafni upload dataset-version --help",
             # "dafni upload dataset-version d0bc2c54-69f8-4057-bae4-99476125f15c sunshine-tiny.zip --version-message \"Yet another new version test\"",
         ],
+        "dataset-metadata": [
+            "dafni upload dataset-metadata --help",
+            # "dafni upload dataset-metadata d0bc2c54-69f8-4057-bae4-99476125f15c sunshine-tiny.zip --version-message \"New metadata version test\"",
+        ],
         "workflow": [
             "dafni upload workflow --help",
             # "dafni upload workflow workflow-upload.json",

--- a/test/api/test_datasets_api.py
+++ b/test/api/test_datasets_api.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from dafni_cli.api import datasets_api
 from dafni_cli.api.exceptions import EndpointNotFoundError, ResourceNotFoundError
-from dafni_cli.consts import SEARCH_AND_DISCOVERY_API_URL
+from dafni_cli.consts import NID_API_URL, SEARCH_AND_DISCOVERY_API_URL
 
 
 class TestDatasetsAPI(TestCase):
@@ -67,3 +67,66 @@ class TestDatasetsAPI(TestCase):
             str(err.exception),
             f"Unable to find a dataset with version_id '{version_id}'",
         )
+
+    def test_upload_dataset_metadata(self):
+        """Tests that upload_dataset_metadata works as expected using
+        default values"""
+
+        # SETUP
+        session = MagicMock()
+        temp_bucket_id = "temp-bucket-id"
+        metadata = {"test": "dictionary"}
+
+        # CALL
+        result = datasets_api.upload_dataset_metadata(session, temp_bucket_id, metadata)
+
+        # ASSERT
+        session.post_request.assert_called_once_with(
+            url=f"{NID_API_URL}/nid/dataset/",
+            json={"bucketId": temp_bucket_id, "metadata": metadata},
+        )
+        self.assertEqual(result, session.post_request.return_value)
+
+    def test_upload_dataset_metadata_with_dataset_id(self):
+        """Tests that upload_dataset_metadata works as expected when given
+        a dataset_id"""
+
+        # SETUP
+        session = MagicMock()
+        temp_bucket_id = "temp-bucket-id"
+        metadata = {"test": "dictionary"}
+        dataset_id = "some-dataset-id"
+
+        # CALL
+        result = datasets_api.upload_dataset_metadata(
+            session, temp_bucket_id, metadata, dataset_id=dataset_id
+        )
+
+        # ASSERT
+        session.post_request.assert_called_once_with(
+            url=f"{NID_API_URL}/nid/dataset/{dataset_id}",
+            json={"bucketId": temp_bucket_id, "metadata": metadata},
+        )
+        self.assertEqual(result, session.post_request.return_value)
+
+    def test_upload_dataset_metadata_version(self):
+        """Tests that upload_dataset_metadata_version works as expected using
+        default values"""
+
+        # SETUP
+        session = MagicMock()
+        dataset_id = "dataset-id"
+        version_id = "version-id"
+        metadata = {"test": "dictionary"}
+
+        # CALL
+        result = datasets_api.upload_dataset_metadata_version(
+            session, dataset_id, version_id, metadata
+        )
+
+        # ASSERT
+        session.post_request.assert_called_once_with(
+            url=f"{NID_API_URL}/nid/metadata/{dataset_id}/{version_id}",
+            json={"metadata": metadata},
+        )
+        self.assertEqual(result, session.post_request.return_value)

--- a/test/api/test_minio_api.py
+++ b/test/api/test_minio_api.py
@@ -84,47 +84,6 @@ class TestMinioAPI(TestCase):
         )
         self.assertEqual(result, session.patch_request.return_value)
 
-    def test_upload_dataset_metadata(self):
-        """Tests that upload_dataset_metadata works as expected using
-        default values"""
-
-        # SETUP
-        session = MagicMock()
-        temp_bucket_id = "temp-bucket-id"
-        metadata = {"test": "dictionary"}
-
-        # CALL
-        result = minio_api.upload_dataset_metadata(session, temp_bucket_id, metadata)
-
-        # ASSERT
-        session.post_request.assert_called_once_with(
-            url=f"{NID_API_URL}/nid/dataset/",
-            json={"bucketId": temp_bucket_id, "metadata": metadata},
-        )
-        self.assertEqual(result, session.post_request.return_value)
-
-    def test_upload_dataset_metadata_with_dataset_id(self):
-        """Tests that upload_dataset_metadata works as expected when given
-        a dataset_id"""
-
-        # SETUP
-        session = MagicMock()
-        temp_bucket_id = "temp-bucket-id"
-        metadata = {"test": "dictionary"}
-        dataset_id = "some-dataset-id"
-
-        # CALL
-        result = minio_api.upload_dataset_metadata(
-            session, temp_bucket_id, metadata, dataset_id=dataset_id
-        )
-
-        # ASSERT
-        session.post_request.assert_called_once_with(
-            url=f"{NID_API_URL}/nid/dataset/{dataset_id}",
-            json={"bucketId": temp_bucket_id, "metadata": metadata},
-        )
-        self.assertEqual(result, session.post_request.return_value)
-
     def test_minio_get_request(self):
         """Tests that minio_get_request works as expected"""
 

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -1,14 +1,12 @@
 from pathlib import Path
 from unittest import TestCase
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
-from dafni_cli.api.exceptions import ValidationError
 from dafni_cli.commands import upload
 from dafni_cli.datasets.dataset_metadata import parse_dataset_metadata
 
-from test.api.test_models_api import TEST_MODELS_UPLOAD_RESPONSE
 from test.fixtures.dataset_metadata import TEST_DATASET_METADATA
 
 

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -227,7 +227,7 @@ class TestUploadDataset(TestCase):
 
         # CALL
         with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
+            with open("test_metadata.json", "w", encoding="utf-8") as file:
                 file.write("{}")
             with open("test_dataset.txt", "w", encoding="utf-8") as file:
                 file.write("test dataset file")
@@ -235,7 +235,7 @@ class TestUploadDataset(TestCase):
                 upload.upload,
                 [
                     "dataset",
-                    "test_definition.json",
+                    "test_metadata.json",
                     "test_dataset.txt",
                 ],
                 input="y",
@@ -249,7 +249,7 @@ class TestUploadDataset(TestCase):
 
         self.assertEqual(
             result.output,
-            "Dataset definition file path: test_definition.json\n"
+            "Dataset metadata file path: test_metadata.json\n"
             "Dataset file path: test_dataset.txt\n"
             "Confirm dataset upload? [y/N]: y\n",
         )
@@ -270,7 +270,7 @@ class TestUploadDataset(TestCase):
 
         # CALL
         with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
+            with open("test_metadata.json", "w", encoding="utf-8") as file:
                 file.write("{}")
             with open("test_dataset1.txt", "w", encoding="utf-8") as file:
                 file.write("test dataset file1")
@@ -280,7 +280,7 @@ class TestUploadDataset(TestCase):
                 upload.upload,
                 [
                     "dataset",
-                    "test_definition.json",
+                    "test_metadata.json",
                     "test_dataset1.txt",
                     "test_dataset2.txt",
                 ],
@@ -297,7 +297,7 @@ class TestUploadDataset(TestCase):
 
         self.assertEqual(
             result.output,
-            "Dataset definition file path: test_definition.json\n"
+            "Dataset metadata file path: test_metadata.json\n"
             "Dataset file path: test_dataset1.txt\n"
             "Dataset file path: test_dataset2.txt\n"
             "Confirm dataset upload? [y/N]: y\n",
@@ -318,7 +318,7 @@ class TestUploadDataset(TestCase):
 
         # CALL
         with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
+            with open("test_metadata.json", "w", encoding="utf-8") as file:
                 file.write("{}")
             with open("test_dataset.txt", "w", encoding="utf-8") as file:
                 file.write("test dataset file")
@@ -326,7 +326,7 @@ class TestUploadDataset(TestCase):
                 upload.upload,
                 [
                     "dataset",
-                    "test_definition.json",
+                    "test_metadata.json",
                     "test_dataset.txt",
                 ],
                 input="n",
@@ -338,7 +338,7 @@ class TestUploadDataset(TestCase):
 
         self.assertEqual(
             result.output,
-            "Dataset definition file path: test_definition.json\n"
+            "Dataset metadata file path: test_metadata.json\n"
             "Dataset file path: test_dataset.txt\n"
             "Confirm dataset upload? [y/N]: n\n"
             "Aborted!\n",
@@ -392,7 +392,7 @@ class TestUploadDatasetVersion(TestCase):
         )
         mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
-            definition_path=None,
+            metadata_path=None,
             version_message=None,
         )
         mock_upload_dataset.assert_called_once_with(
@@ -450,7 +450,7 @@ class TestUploadDatasetVersion(TestCase):
         )
         mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
-            definition_path=None,
+            metadata_path=None,
             version_message=None,
         )
         mock_upload_dataset.assert_called_once_with(
@@ -510,7 +510,7 @@ class TestUploadDatasetVersion(TestCase):
         )
         mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
-            definition_path=None,
+            metadata_path=None,
             version_message=None,
         )
         mock_upload_dataset.assert_not_called()
@@ -526,7 +526,7 @@ class TestUploadDatasetVersion(TestCase):
         )
         self.assertEqual(result.exit_code, 1)
 
-    def test_upload_dataset_version_with_definition_and_version_message(
+    def test_upload_dataset_version_with_metadata_and_version_message(
         self,
         mock_modify_dataset_metadata_for_upload,
         mock_get_latest_dataset_metadata,
@@ -542,7 +542,7 @@ class TestUploadDatasetVersion(TestCase):
         runner = CliRunner()
         dataset_version_id = "some-existing-version-id"
         file_path = "test_dataset.txt"
-        definition_path = "definition.json"
+        metadata_path = "definition.json"
         version_message = "version_message"
         mock_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
@@ -551,16 +551,16 @@ class TestUploadDatasetVersion(TestCase):
         with runner.isolated_filesystem():
             with open(file_path, "w", encoding="utf-8") as file:
                 file.write("test dataset file")
-            with open(definition_path, "w", encoding="utf-8") as file:
-                file.write("test definition file")
+            with open(metadata_path, "w", encoding="utf-8") as file:
+                file.write("test metadata file")
             result = runner.invoke(
                 upload.upload,
                 [
                     "dataset-version",
                     dataset_version_id,
                     file_path,
-                    "--definition",
-                    definition_path,
+                    "--metadata",
+                    metadata_path,
                     "--version-message",
                     version_message,
                 ],
@@ -574,7 +574,7 @@ class TestUploadDatasetVersion(TestCase):
         )
         mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
-            definition_path=Path(definition_path),
+            metadata_path=Path(metadata_path),
             version_message=version_message,
         )
         mock_upload_dataset.assert_called_once_with(
@@ -590,7 +590,7 @@ class TestUploadDatasetVersion(TestCase):
             f"Dataset ID: {metadata.dataset_id}\n"
             f"Dataset Version ID: {metadata.version_id}\n"
             f"Dataset file path: {file_path}\n"
-            f"Dataset definition file path: {definition_path}\n"
+            f"Dataset metadata file path: {metadata_path}\n"
             "Confirm dataset upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
@@ -638,7 +638,7 @@ class TestUploadDatasetMetadata(TestCase):
         )
         mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
-            definition_path=None,
+            metadata_path=None,
             version_message=None,
         )
         mock_upload_dataset_metadata_version.assert_called_once_with(
@@ -692,7 +692,7 @@ class TestUploadDatasetMetadata(TestCase):
         )
         mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
-            definition_path=None,
+            metadata_path=None,
             version_message=None,
         )
         mock_upload_dataset_metadata_version.assert_not_called()
@@ -707,7 +707,7 @@ class TestUploadDatasetMetadata(TestCase):
         )
         self.assertEqual(result.exit_code, 1)
 
-    def test_upload_dataset_metadata_with_definition_and_version_message(
+    def test_upload_dataset_metadata_with_metadata_and_version_message(
         self,
         mock_modify_dataset_metadata_for_upload,
         mock_get_latest_dataset_metadata,
@@ -722,22 +722,22 @@ class TestUploadDatasetMetadata(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         dataset_version_id = "some-existing-version-id"
-        definition_path = "definition.json"
+        metadata_path = "metadata.json"
         version_message = "version_message"
         mock_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         # CALL
         with runner.isolated_filesystem():
-            with open(definition_path, "w", encoding="utf-8") as file:
-                file.write("test definition file")
+            with open(metadata_path, "w", encoding="utf-8") as file:
+                file.write("test metadata file")
             result = runner.invoke(
                 upload.upload,
                 [
                     "dataset-metadata",
                     dataset_version_id,
-                    "--definition",
-                    definition_path,
+                    "--metadata",
+                    metadata_path,
                     "--version-message",
                     version_message,
                 ],
@@ -751,7 +751,7 @@ class TestUploadDatasetMetadata(TestCase):
         )
         mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
-            definition_path=Path(definition_path),
+            metadata_path=Path(metadata_path),
             version_message=version_message,
         )
         mock_upload_dataset_metadata_version.assert_called_once_with(
@@ -766,7 +766,7 @@ class TestUploadDatasetMetadata(TestCase):
             f"Dataset Title: {metadata.title}\n"
             f"Dataset ID: {metadata.dataset_id}\n"
             f"Dataset Version ID: {metadata.version_id}\n"
-            f"Dataset definition file path: {definition_path}\n"
+            f"Dataset metadata file path: {metadata_path}\n"
             "Confirm metadata upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -841,7 +841,7 @@ class TestUploadDatasetMetadata(TestCase):
         mock_upload_dataset_metadata_version,
         mock_DAFNISession,
     ):
-        """Tests that the 'upload dataset-version' command can be canceled"""
+        """Tests that the 'upload dataset-metadata' command can be canceled"""
 
         # SETUP
         session = MagicMock()

--- a/test/datasets/test_dataset_upload.py
+++ b/test/datasets/test_dataset_upload.py
@@ -148,19 +148,19 @@ class TestDatasetUpload(TestCase):
         )
 
     @patch("dafni_cli.datasets.dataset_upload.upload_dataset_metadata")
-    def test_upload_metadata(
+    def test_commit_metadata(
         self,
         mock_upload_dataset_metadata,
         mock_click,
     ):
-        """Tests that upload_metadata works as expected without a dataset_id"""
+        """Tests that _commit_metadata works as expected without a dataset_id"""
         # SETUP
         session = MagicMock()
         metadata = MOCK_DEFINITION_DATA
         temp_bucket_id = "some-temp-bucket"
 
         # CALL
-        result = dataset_upload.upload_metadata(session, metadata, temp_bucket_id)
+        result = dataset_upload._commit_metadata(session, metadata, temp_bucket_id)
 
         # ASSERT
         mock_upload_dataset_metadata.assert_called_with(
@@ -175,12 +175,12 @@ class TestDatasetUpload(TestCase):
         self.assertEqual(result, mock_upload_dataset_metadata.return_value)
 
     @patch("dafni_cli.datasets.dataset_upload.upload_dataset_metadata")
-    def test_upload_metadata_with_dataset_id(
+    def test_commit_metadata_with_dataset_id(
         self,
         mock_upload_dataset_metadata,
         mock_click,
     ):
-        """Tests that upload_metadata works as expected with a dataset_id"""
+        """Tests that _commit_metadata works as expected with a dataset_id"""
         # SETUP
         session = MagicMock()
         metadata = MOCK_DEFINITION_DATA
@@ -188,7 +188,7 @@ class TestDatasetUpload(TestCase):
         dataset_id = "some-dataset-id"
 
         # CALL
-        result = dataset_upload.upload_metadata(
+        result = dataset_upload._commit_metadata(
             session, metadata, temp_bucket_id, dataset_id=dataset_id
         )
 
@@ -205,12 +205,12 @@ class TestDatasetUpload(TestCase):
         self.assertEqual(result, mock_upload_dataset_metadata.return_value)
 
     @patch("dafni_cli.datasets.dataset_upload.upload_dataset_metadata")
-    def test_upload_metadata_exits_on_error(
+    def test_commit_metadata_exits_on_error(
         self,
         mock_upload_dataset_metadata,
         mock_click,
     ):
-        """Tests that upload_metadata calls SystemExit(1) when an error occurs"""
+        """Tests that _commit_metadata calls SystemExit(1) when an error occurs"""
         # SETUP
         session = MagicMock()
         metadata = MOCK_DEFINITION_DATA
@@ -221,7 +221,7 @@ class TestDatasetUpload(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            dataset_upload.upload_metadata(session, metadata, temp_bucket_id)
+            dataset_upload._commit_metadata(session, metadata, temp_bucket_id)
 
         # ASSERT
         mock_click.echo.assert_has_calls(
@@ -232,12 +232,12 @@ class TestDatasetUpload(TestCase):
         )
 
     @patch("dafni_cli.datasets.dataset_upload.upload_files")
-    @patch("dafni_cli.datasets.dataset_upload.upload_metadata")
+    @patch("dafni_cli.datasets.dataset_upload._commit_metadata")
     @patch("dafni_cli.datasets.dataset_upload.create_temp_bucket")
     def test_upload_dataset(
         self,
         mock_create_temp_bucket,
-        mock_upload_metadata,
+        mock_commit_metadata,
         mock_upload_files,
         mock_click,
     ):
@@ -255,7 +255,7 @@ class TestDatasetUpload(TestCase):
         }
 
         mock_create_temp_bucket.return_value = temp_bucket_id
-        mock_upload_metadata.return_value = details
+        mock_commit_metadata.return_value = details
 
         # CALL
         dataset_upload.upload_dataset(session, definition_path, file_paths, dataset_id)
@@ -267,7 +267,7 @@ class TestDatasetUpload(TestCase):
             temp_bucket_id,
             file_paths,
         )
-        mock_upload_metadata.assert_called_once_with(
+        mock_commit_metadata.assert_called_once_with(
             session, definition_path, temp_bucket_id, dataset_id=dataset_id
         )
 
@@ -282,14 +282,14 @@ class TestDatasetUpload(TestCase):
         )
 
     @patch("dafni_cli.datasets.dataset_upload.upload_files")
-    @patch("dafni_cli.datasets.dataset_upload.upload_metadata")
+    @patch("dafni_cli.datasets.dataset_upload._commit_metadata")
     @patch("dafni_cli.datasets.dataset_upload.create_temp_bucket")
     @patch("dafni_cli.datasets.dataset_upload.delete_temp_bucket")
     def test_upload_dataset_deletes_bucket_on_error(
         self,
         mock_delete_temp_bucket,
         mock_create_temp_bucket,
-        mock_upload_metadata,
+        mock_commit_metadata,
         mock_upload_files,
         mock_click,
     ):
@@ -302,7 +302,7 @@ class TestDatasetUpload(TestCase):
         temp_bucket_id = "some-temp-bucket"
 
         mock_create_temp_bucket.return_value = temp_bucket_id
-        mock_upload_metadata.side_effect = HTTPError(400)
+        mock_commit_metadata.side_effect = HTTPError(400)
 
         # CALL
         with self.assertRaises(HTTPError):
@@ -315,7 +315,7 @@ class TestDatasetUpload(TestCase):
             temp_bucket_id,
             file_paths,
         )
-        mock_upload_metadata.assert_called_once_with(
+        mock_commit_metadata.assert_called_once_with(
             session, definition_path, temp_bucket_id, dataset_id=None
         )
         mock_delete_temp_bucket.assert_called_once_with(session, temp_bucket_id)
@@ -328,14 +328,14 @@ class TestDatasetUpload(TestCase):
         )
 
     @patch("dafni_cli.datasets.dataset_upload.upload_files")
-    @patch("dafni_cli.datasets.dataset_upload.upload_metadata")
+    @patch("dafni_cli.datasets.dataset_upload._commit_metadata")
     @patch("dafni_cli.datasets.dataset_upload.create_temp_bucket")
     @patch("dafni_cli.datasets.dataset_upload.delete_temp_bucket")
     def test_upload_dataset_deletes_bucket_on_system_exit(
         self,
         mock_delete_temp_bucket,
         mock_create_temp_bucket,
-        mock_upload_metadata,
+        mock_commit_metadata,
         mock_upload_files,
         mock_click,
     ):
@@ -348,7 +348,7 @@ class TestDatasetUpload(TestCase):
         temp_bucket_id = "some-temp-bucket"
 
         mock_create_temp_bucket.return_value = temp_bucket_id
-        mock_upload_metadata.side_effect = SystemExit(1)
+        mock_commit_metadata.side_effect = SystemExit(1)
 
         # CALL
         with self.assertRaises(SystemExit):
@@ -361,7 +361,7 @@ class TestDatasetUpload(TestCase):
             temp_bucket_id,
             file_paths,
         )
-        mock_upload_metadata.assert_called_once_with(
+        mock_commit_metadata.assert_called_once_with(
             session, definition_path, temp_bucket_id, dataset_id=None
         )
         mock_delete_temp_bucket.assert_called_once_with(session, temp_bucket_id)


### PR DESCRIPTION
Adds a command `dafni upload dataset-metadata` to upload new metadata to create a new metadata version on an existing dataset. Like #78 there is a --save option for saving existing metadata for modifying it manually.

Other changes:
- Renamed 'definition' to 'metadata' throughout the dataset commands as I thought it made it clearer
