### PR TITLE
feat: Add delete dataset-version command [CORE-2734]

### DIFF
--- a/dafni_cli/api/datasets_api.py
+++ b/dafni_cli/api/datasets_api.py
@@ -59,3 +59,17 @@ def delete_dataset(session: DAFNISession, dataset_id: str) -> Response:
     """
     url = f"{NID_API_URL}/nid/dataset/{dataset_id}"
     return session.delete_request(url)
+
+
+def delete_dataset_version(
+    session: DAFNISession, dataset_id: str, version_id: str
+) -> Response:
+    """Calls the NID to delete a dataset version
+
+    Args:
+        session (DAFNISession): User session
+        dataset_id (str): Dataset ID for selected dataset
+        version_id (str): Dataset version ID for selected dataset
+    """
+    url = f"{NID_API_URL}/nid/dataset/{dataset_id}/{version_id}"
+    return session.delete_request(url)

--- a/dafni_cli/commands/delete.py
+++ b/dafni_cli/commands/delete.py
@@ -36,21 +36,21 @@ def delete(ctx: Context):
 # Models
 ###############################################################################
 def collate_model_version_details(
-    session: DAFNISession, version_id_list: List[str]
+    session: DAFNISession, version_ids: Tuple[str]
 ) -> List[str]:
-    """
-    Checks for destroy privileges for the user, and produces a list of the
-    version details of each model to be deleted
+    """For each given model version, checks for destroy privileges for the
+    user and produces a list of the version details of each model to be
+    deleted
 
     Args:
         session (DAFNISession): User session
-        version_id_list (List[str]): List of the version IDs of each model to be deleted
+        version_ids (Tuple[str]): Tuple of the version IDs of each model to be deleted
 
     Returns:
         List[str]: List of the model details to be displayed during deletion confirmation
     """
     model_version_details_list = []
-    for vid in version_id_list:
+    for vid in version_ids:
         # Find details of each model version that will be deleted
         model_version: Model = parse_model(get_model(session, vid))
         # Exit if user doesn't have necessary permissions
@@ -65,21 +65,21 @@ def collate_model_version_details(
 
 
 @delete.command(help="Delete one or more model version(s)")
-@click.argument("version-id", nargs=-1, required=True, type=str)
+@click.argument("version-ids", nargs=-1, required=True, type=str)
 @click.pass_context
-def model(ctx: Context, version_id: List[str]):
+def model(ctx: Context, version_ids: List[str]):
     """
     Delete one or more version(s) of model(s) from DAFNI.
 
     Args:
         ctx (context): contains user session for authentication
-        version_id (str): ID(s) of the model version(s) to be deleted
+        version_ids (Tuple[str]): ID(s) of the model version(s) to be deleted
     """
     model_version_details_list = collate_model_version_details(
-        ctx.obj["session"], version_id
+        ctx.obj["session"], version_ids
     )
     argument_confirmation([], "Confirm deletion of models?", model_version_details_list)
-    for vid in version_id:
+    for vid in version_ids:
         delete_model(ctx.obj["session"], vid)
     # Confirm action
     click.echo("Model versions deleted")
@@ -90,18 +90,17 @@ def model(ctx: Context, version_id: List[str]):
 ###############################################################################
 def _collate_dataset_details(
     session: DAFNISession,
-    version_id_list: List[str],
+    version_ids: Tuple[str],
     obtain_details: Callable[[DatasetMetadata], str],
     permissions_message: str,
 ) -> Tuple[List[str], List[str]]:
-    """
-    Checks for destroy privileges for the user, and produces a list of the
-    details of each dataset to be deleted
+    """For each given dataset version, checks for destroy privileges for the
+    user and produces a list of the details of each dataset to be deleted
 
     Args:
         session (DAFNISession): User session
-        version_id_list (List[str]): List of the dataset version IDs of each
-                                     dataset to be deleted
+        version_ids (Tuple[str]): Tuple of the dataset version IDs of each
+                                  dataset to be deleted
         obtain_details (Callable[[DatasetMetadata], str]): Function that
                             returns a string containing relevant details when
                             passed a metadata object
@@ -117,7 +116,7 @@ def _collate_dataset_details(
     """
     dataset_details_list = []
     dataset_ids = []
-    for vid in version_id_list:
+    for vid in version_ids:
         # Find details of each dataset that will be deleted
         dataset_meta: DatasetMetadata = parse_dataset_metadata(
             get_latest_dataset_metadata(session, vid)
@@ -134,16 +133,15 @@ def _collate_dataset_details(
 
 
 def collate_dataset_details(
-    session: DAFNISession, version_id_list: List[str]
+    session: DAFNISession, version_ids: List[str]
 ) -> Tuple[List[str], List[str]]:
-    """
-    Checks for destroy privileges for the user, and produces a list of the
-    details of each dataset to be deleted
+    """For each given dataset, checks for destroy privileges for the
+    user and produces a list of the details of each dataset to be deleted
 
     Args:
         session (DAFNISession): User session
-        version_id_list (List[str]): List of the dataset version IDs of each
-                                     dataset to be deleted
+        version_ids (Tuple[str]): Tuple of the dataset version IDs of each
+                                  dataset to be deleted
 
     Returns:
         List[str]: List of the dataset details to be displayed during deletion
@@ -152,30 +150,30 @@ def collate_dataset_details(
     """
     return _collate_dataset_details(
         session=session,
-        version_id_list=version_id_list,
+        version_ids=version_ids,
         obtain_details=lambda dataset_meta: dataset_meta.get_dataset_details(),
         permissions_message="You do not have sufficient permissions to delete dataset:",
     )
 
 
 @delete.command(help="Delete one or more datasets")
-@click.argument("version-id", nargs=-1, required=True, type=str)
+@click.argument("version-ids", nargs=-1, required=True, type=str)
 @click.pass_context
-def dataset(ctx: Context, version_id: List[str]):
+def dataset(ctx: Context, version_ids: Tuple[str]):
     """
     Delete one or more dataset(s) from DAFNI.
 
     Args:
         ctx (context): contains user session for authentication
-        version_id (str): Version ID(s) of the datasets to be deleted
+        version_ids (Tuple[str]): Version ID(s) of the datasets to be deleted
     """
 
     # We need the version id to get the metadata, but the dataset id for the
     # actual delete - instead of requiring both, we look up dataset with the
-    # version_id and obtain both the id and metadata once
+    # version id and obtain both the id and metadata once
 
     dataset_details_list, dataset_ids = collate_dataset_details(
-        ctx.obj["session"], version_id
+        ctx.obj["session"], version_ids
     )
     argument_confirmation([], "Confirm deletion of datasets?", dataset_details_list)
     for dataset_id in dataset_ids:
@@ -185,16 +183,16 @@ def dataset(ctx: Context, version_id: List[str]):
 
 
 def collate_dataset_version_details(
-    session: DAFNISession, version_id_list: List[str]
+    session: DAFNISession, version_ids: Tuple[str]
 ) -> Tuple[List[str], List[str]]:
-    """
-    Checks for destroy privileges for the user, and produces a list of the
-    details of each dataset to be deleted
+    """For each given dataset version, checks for destroy privileges for the
+    user and produces a list of the version details of each dataset version to
+    be deleted
 
     Args:
         session (DAFNISession): User session
-        version_id_list (List[str]): List of the dataset version IDs of each
-                                     dataset to be deleted
+        version_ids (Tuple[str]): Tuple of the dataset version IDs of each
+                                  dataset to be deleted
 
     Returns:
         List[str]: List of the dataset details to be displayed during deletion
@@ -203,31 +201,31 @@ def collate_dataset_version_details(
     """
     return _collate_dataset_details(
         session=session,
-        version_id_list=version_id_list,
+        version_ids=version_ids,
         obtain_details=lambda dataset_meta: dataset_meta.get_dataset_version_details(),
         permissions_message="You do not have sufficient permissions to delete dataset version:",
     )
 
 
 @delete.command(help="Delete one or more dataset versions")
-@click.argument("version-id", nargs=-1, required=True, type=str)
+@click.argument("version-ids", nargs=-1, required=True, type=str)
 @click.pass_context
-def dataset_version(ctx: Context, version_id: List[str]):
+def dataset_version(ctx: Context, version_ids: Tuple[str]):
     """
     Delete one or more dataset version(s) from DAFNI.
 
     Args:
         ctx (context): contains user session for authentication
-        version_id (str): Version ID(s) of the datasets to be deleted
+        version_ids (str): Version ID(s) of the datasets to be deleted
     """
 
     dataset_details_list, dataset_ids = collate_dataset_version_details(
-        ctx.obj["session"], version_id
+        ctx.obj["session"], version_ids
     )
     argument_confirmation(
         [], "Confirm deletion of dataset versions?", dataset_details_list
     )
-    for dataset_id, vid in zip(dataset_ids, version_id):
+    for dataset_id, vid in zip(dataset_ids, version_ids):
         delete_dataset_version(
             ctx.obj["session"], dataset_id=dataset_id, version_id=vid
         )
@@ -239,7 +237,7 @@ def dataset_version(ctx: Context, version_id: List[str]):
 # Workflows
 ###############################################################################
 def collate_workflow_version_details(
-    session: DAFNISession, version_id_list: List[str]
+    session: DAFNISession, version_ids: Tuple[str]
 ) -> List[str]:
     """
     Checks for destroy privileges for the user, and produces a list of the version details
@@ -247,13 +245,13 @@ def collate_workflow_version_details(
 
     Args:
         session (DAFNISession): User session
-        version_id_list (List[str]): List of the version IDs of each workflow to be deleted
+        version_ids (Tuple[str]): List of the version IDs of each workflow to be deleted
 
     Returns:
         List[str]: List of the workflow  details to be displayed during deletion confirmation
     """
     workflow_version_details_list = []
-    for vid in version_id_list:
+    for vid in version_ids:
         # Find details of each workflow version that will be deleted
         workflow_version = parse_workflow(get_workflow(session, vid))
         # Exit if user doesn't have necessary permissions
@@ -268,23 +266,23 @@ def collate_workflow_version_details(
 
 
 @delete.command(help="Delete one or more workflow version(s)")
-@click.argument("version-id", nargs=-1, required=True, type=str)
+@click.argument("version-ids", nargs=-1, required=True, type=str)
 @click.pass_context
-def workflow(ctx: Context, version_id: List[str]):
+def workflow(ctx: Context, version_ids: Tuple[str]):
     """
     Delete one or more version(s) of workflow(s) from DAFNI.
 
     Args:
         ctx (context): contains user session for authentication
-        version_id (str): ID(s) of the workflow version(s) to be deleted
+        version_ids (Tuple[str]): ID(s) of the workflow version(s) to be deleted
     """
     workflow_version_details_list = collate_workflow_version_details(
-        ctx.obj["session"], version_id
+        ctx.obj["session"], version_ids
     )
     argument_confirmation(
         [], "Confirm deletion of workflows?", workflow_version_details_list
     )
-    for vid in version_id:
+    for vid in version_ids:
         delete_workflow(ctx.obj["session"], vid)
     # Confirm action
     click.echo("Workflow versions deleted")

--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -460,9 +460,19 @@ class DatasetMetadata(ParserBaseObject):
         return (
             f"Title: {self.title}\n"
             f"ID: {self.dataset_id}\n"
-            f"Latest version: {self.version_id}\n"
+            f"Created: {format_datetime(self.created, include_time=True)}\n"
             f"Publisher: {self.publisher.name}\n"
             f"Version IDs:\n{version_ids}\n"
+        )
+
+    def get_dataset_version_details(self) -> str:
+        """Returns a string with details about the dataset version (used prior
+        to deletion)"""
+        return (
+            f"Title: {self.title}\n"
+            f"Version ID: {self.version_id}\n"
+            f"Created: {format_datetime(self.created, include_time=True)}\n"
+            f"Publisher: {self.publisher.name}\n"
         )
 
     def download_dataset_files(

--- a/test/api/test_datasets_api.py
+++ b/test/api/test_datasets_api.py
@@ -83,3 +83,22 @@ class TestDatasetsAPI(TestCase):
             f"{NID_API_URL}/nid/dataset/{dataset_id}",
         )
         self.assertEqual(result, session.delete_request.return_value)
+
+    def test_delete_dataset_version(self):
+        """Tests that delete_dataset_version works as expected"""
+
+        # SETUP
+        session = MagicMock()
+        dataset_id = "dataset-id"
+        version_id = "version-id"
+
+        # CALL
+        result = datasets_api.delete_dataset_version(
+            session, dataset_id=dataset_id, version_id=version_id
+        )
+
+        # ASSERT
+        session.delete_request.assert_called_once_with(
+            f"{NID_API_URL}/nid/dataset/{dataset_id}/{version_id}",
+        )
+        self.assertEqual(result, session.delete_request.return_value)

--- a/test/commands/test_delete.py
+++ b/test/commands/test_delete.py
@@ -20,7 +20,7 @@ class TestCollateModelVersionDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         model_mock = MagicMock()
         model_mock.auth.destroy = True
@@ -28,7 +28,7 @@ class TestCollateModelVersionDetails(TestCase):
         mock_parse_model.return_value = model_mock
 
         # CALL
-        result = delete.collate_model_version_details(session, version_id_list)
+        result = delete.collate_model_version_details(session, version_ids)
 
         # ASSERT
         mock_get_model.assert_called_once_with(session, version_id)
@@ -45,7 +45,7 @@ class TestCollateModelVersionDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         model_mock = MagicMock()
         model_mock.auth.destroy = False
@@ -54,7 +54,7 @@ class TestCollateModelVersionDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_model_version_details(session, version_id_list)
+            delete.collate_model_version_details(session, version_ids)
 
         # ASSERT
         mock_get_model.assert_called_once_with(session, version_id)
@@ -76,7 +76,7 @@ class TestCollateModelVersionDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = (version_id1, version_id2)
 
         model_mock1 = MagicMock()
         model_mock1.auth.destroy = True
@@ -86,7 +86,7 @@ class TestCollateModelVersionDetails(TestCase):
         mock_parse_model.side_effect = [model_mock1, model_mock2]
 
         # CALL
-        result = delete.collate_model_version_details(session, version_id_list)
+        result = delete.collate_model_version_details(session, version_ids)
 
         # ASSERT
         mock_get_model.assert_has_calls(
@@ -114,7 +114,7 @@ class TestCollateModelVersionDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = [version_id1, version_id2]
 
         model_mock1 = MagicMock()
         model_mock1.auth.destroy = True
@@ -125,7 +125,7 @@ class TestCollateModelVersionDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_model_version_details(session, version_id_list)
+            delete.collate_model_version_details(session, version_ids)
 
         # ASSERT
         mock_get_model.assert_has_calls(
@@ -157,7 +157,7 @@ class TestCollateDatasetDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         dataset_mock = MagicMock()
         dataset_mock.dataset_id = "dataset-id"
@@ -166,7 +166,7 @@ class TestCollateDatasetDetails(TestCase):
         mock_parse_dataset_metadata.return_value = dataset_mock
 
         # CALL
-        result = delete.collate_dataset_details(session, version_id_list)
+        result = delete.collate_dataset_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
@@ -191,7 +191,7 @@ class TestCollateDatasetDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         dataset_mock = MagicMock()
         dataset_mock.dataset_id = "dataset-id"
@@ -201,7 +201,7 @@ class TestCollateDatasetDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_dataset_details(session, version_id_list)
+            delete.collate_dataset_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
@@ -225,7 +225,7 @@ class TestCollateDatasetDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = (version_id1, version_id2)
 
         dataset_mock1 = MagicMock()
         dataset_mock1.dataset_id = "dataset-id-1"
@@ -237,7 +237,7 @@ class TestCollateDatasetDetails(TestCase):
         mock_parse_dataset_metadata.side_effect = [dataset_mock1, dataset_mock2]
 
         # CALL
-        result = delete.collate_dataset_details(session, version_id_list)
+        result = delete.collate_dataset_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_has_calls(
@@ -272,7 +272,7 @@ class TestCollateDatasetDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = (version_id1, version_id2)
 
         dataset_mock1 = MagicMock()
         dataset_mock1.dataset_id = "dataset-id-1"
@@ -285,7 +285,7 @@ class TestCollateDatasetDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_dataset_details(session, version_id_list)
+            delete.collate_dataset_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_has_calls(
@@ -309,7 +309,7 @@ class TestCollateDatasetDetails(TestCase):
 @patch("dafni_cli.commands.delete.get_latest_dataset_metadata")
 @patch("dafni_cli.commands.delete.parse_dataset_metadata")
 class TestCollateDatasetVersionDetails(TestCase):
-    """Test class to test the collate_dataset_details function"""
+    """Test class to test the collate_dataset_version_details function"""
 
     def test_single_dataset_version_with_valid_permissions_returns_single_dataset_details(
         self, mock_parse_dataset_metadata, mock_get_latest_dataset_metadata
@@ -320,7 +320,7 @@ class TestCollateDatasetVersionDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         dataset_mock = MagicMock()
         dataset_mock.dataset_id = "dataset-id"
@@ -329,7 +329,7 @@ class TestCollateDatasetVersionDetails(TestCase):
         mock_parse_dataset_metadata.return_value = dataset_mock
 
         # CALL
-        result = delete.collate_dataset_version_details(session, version_id_list)
+        result = delete.collate_dataset_version_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
@@ -354,7 +354,7 @@ class TestCollateDatasetVersionDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         dataset_mock = MagicMock()
         dataset_mock.dataset_id = "dataset-id"
@@ -364,7 +364,7 @@ class TestCollateDatasetVersionDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_dataset_version_details(session, version_id_list)
+            delete.collate_dataset_version_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
@@ -390,7 +390,7 @@ class TestCollateDatasetVersionDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = (version_id1, version_id2)
 
         dataset_mock1 = MagicMock()
         dataset_mock1.dataset_id = "dataset-id-1"
@@ -402,7 +402,7 @@ class TestCollateDatasetVersionDetails(TestCase):
         mock_parse_dataset_metadata.side_effect = [dataset_mock1, dataset_mock2]
 
         # CALL
-        result = delete.collate_dataset_version_details(session, version_id_list)
+        result = delete.collate_dataset_version_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_has_calls(
@@ -437,7 +437,7 @@ class TestCollateDatasetVersionDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = (version_id1, version_id2)
 
         dataset_mock1 = MagicMock()
         dataset_mock1.dataset_id = "dataset-id-1"
@@ -450,7 +450,7 @@ class TestCollateDatasetVersionDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_dataset_version_details(session, version_id_list)
+            delete.collate_dataset_version_details(session, version_ids)
 
         # ASSERT
         mock_get_latest_dataset_metadata.assert_has_calls(
@@ -487,7 +487,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         workflow_mock = MagicMock()
         workflow_mock.auth.destroy = True
@@ -495,7 +495,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
         mock_parse_workflow.return_value = workflow_mock
 
         # CALL
-        result = delete.collate_workflow_version_details(session, version_id_list)
+        result = delete.collate_workflow_version_details(session, version_ids)
 
         # ASSERT
         mock_get_workflow.assert_called_once_with(session, version_id)
@@ -512,7 +512,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
         # SETUP
         session = MagicMock()
         version_id = "version-id"
-        version_id_list = [version_id]
+        version_ids = (version_id,)
 
         workflow_mock = MagicMock()
         workflow_mock.auth.destroy = False
@@ -521,7 +521,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_workflow_version_details(session, version_id_list)
+            delete.collate_workflow_version_details(session, version_ids)
 
         # ASSERT
         mock_get_workflow.assert_called_once_with(session, version_id)
@@ -545,7 +545,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = (version_id1, version_id2)
 
         workflow_mock1 = MagicMock()
         workflow_mock1.auth.destroy = True
@@ -555,7 +555,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
         mock_parse_workflow.side_effect = [workflow_mock1, workflow_mock2]
 
         # CALL
-        result = delete.collate_workflow_version_details(session, version_id_list)
+        result = delete.collate_workflow_version_details(session, version_ids)
 
         # ASSERT
         mock_get_workflow.assert_has_calls(
@@ -583,7 +583,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
         session = MagicMock()
         version_id1 = "version-id-1"
         version_id2 = "version-id-2"
-        version_id_list = [version_id1, version_id2]
+        version_ids = (version_id1, version_id2)
 
         workflow_mock1 = MagicMock()
         workflow_mock1.auth.destroy = True
@@ -594,7 +594,7 @@ class TestCollateWorkflowVersionDetails(TestCase):
 
         # CALL
         with self.assertRaises(SystemExit):
-            delete.collate_workflow_version_details(session, version_id_list)
+            delete.collate_workflow_version_details(session, version_ids)
 
         # ASSERT
         mock_get_workflow.assert_has_calls(
@@ -911,7 +911,7 @@ class TestDelete(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         ctx = {}
-        dataset_ids = ("dataset-id-1", "dataset-id-1")
+        dataset_ids = ("dataset-id-1", "dataset-id-2")
         version_ids = ("version-id-1", "version-id-2")
         mock_collate_dataset_version_details.return_value = (
             [

--- a/test/commands/test_delete.py
+++ b/test/commands/test_delete.py
@@ -9,7 +9,7 @@ from dafni_cli.commands import delete
 @patch("dafni_cli.commands.delete.get_model")
 @patch("dafni_cli.commands.delete.parse_model")
 class TestCollateModelVersionDetails(TestCase):
-    """Test class to collate_model_version_details function"""
+    """Test class to test the collate_model_version_details function"""
 
     def test_single_model_with_valid_permissions_returns_single_model_details(
         self, mock_parse_model, mock_get_model
@@ -146,7 +146,7 @@ class TestCollateModelVersionDetails(TestCase):
 @patch("dafni_cli.commands.delete.get_latest_dataset_metadata")
 @patch("dafni_cli.commands.delete.parse_dataset_metadata")
 class TestCollateDatasetDetails(TestCase):
-    """Test class to collate_dataset_details function"""
+    """Test class to test the collate_dataset_details function"""
 
     def test_single_dataset_with_valid_permissions_returns_single_dataset_details(
         self, mock_parse_dataset_metadata, mock_get_latest_dataset_metadata
@@ -306,10 +306,177 @@ class TestCollateDatasetDetails(TestCase):
         )
 
 
+@patch("dafni_cli.commands.delete.get_latest_dataset_metadata")
+@patch("dafni_cli.commands.delete.parse_dataset_metadata")
+class TestCollateDatasetVersionDetails(TestCase):
+    """Test class to test the collate_dataset_details function"""
+
+    def test_single_dataset_version_with_valid_permissions_returns_single_dataset_details(
+        self, mock_parse_dataset_metadata, mock_get_latest_dataset_metadata
+    ):
+        """Tests collate_dataset_version_details works correctly for a single
+        dataset version with delete permissions"""
+
+        # SETUP
+        session = MagicMock()
+        version_id = "version-id"
+        version_id_list = [version_id]
+
+        dataset_mock = MagicMock()
+        dataset_mock.dataset_id = "dataset-id"
+        dataset_mock.auth.destroy = True
+
+        mock_parse_dataset_metadata.return_value = dataset_mock
+
+        # CALL
+        result = delete.collate_dataset_version_details(session, version_id_list)
+
+        # ASSERT
+        mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
+        mock_parse_dataset_metadata.assert_called_once_with(
+            mock_get_latest_dataset_metadata.return_value
+        )
+        self.assertEqual(
+            result,
+            (
+                [dataset_mock.get_dataset_version_details.return_value],
+                [dataset_mock.dataset_id],
+            ),
+        )
+
+    @patch("dafni_cli.commands.delete.click")
+    def test_single_dataset_version_without_valid_permissions_exits(
+        self, mock_click, mock_parse_dataset_metadata, mock_get_latest_dataset_metadata
+    ):
+        """Tests collate_dataset_version_details works correctly for a single
+        dataset without delete permissions"""
+
+        # SETUP
+        session = MagicMock()
+        version_id = "version-id"
+        version_id_list = [version_id]
+
+        dataset_mock = MagicMock()
+        dataset_mock.dataset_id = "dataset-id"
+        dataset_mock.auth.destroy = False
+
+        mock_parse_dataset_metadata.return_value = dataset_mock
+
+        # CALL
+        with self.assertRaises(SystemExit):
+            delete.collate_dataset_version_details(session, version_id_list)
+
+        # ASSERT
+        mock_get_latest_dataset_metadata.assert_called_once_with(session, version_id)
+        mock_parse_dataset_metadata.assert_called_once_with(
+            mock_get_latest_dataset_metadata.return_value
+        )
+        mock_click.echo.assert_has_calls(
+            [
+                call(
+                    "You do not have sufficient permissions to delete dataset version:"
+                ),
+                call(dataset_mock.get_dataset_version_details.return_value),
+            ]
+        )
+
+    def test_multiple_dataset_versions_with_valid_permissions_returns_multiple_dataset_details(
+        self, mock_parse_dataset_metadata, mock_get_latest_dataset_metadata
+    ):
+        """Tests collate_dataset_version_details works correctly for a list
+        of dataset versions with delete permissions"""
+
+        # SETUP
+        session = MagicMock()
+        version_id1 = "version-id-1"
+        version_id2 = "version-id-2"
+        version_id_list = [version_id1, version_id2]
+
+        dataset_mock1 = MagicMock()
+        dataset_mock1.dataset_id = "dataset-id-1"
+        dataset_mock1.auth.destroy = True
+        dataset_mock2 = MagicMock()
+        dataset_mock2.dataset_id = "dataset-id-2"
+        dataset_mock2.auth.destroy = True
+
+        mock_parse_dataset_metadata.side_effect = [dataset_mock1, dataset_mock2]
+
+        # CALL
+        result = delete.collate_dataset_version_details(session, version_id_list)
+
+        # ASSERT
+        mock_get_latest_dataset_metadata.assert_has_calls(
+            [call(session, version_id1), call(session, version_id2)]
+        )
+        mock_parse_dataset_metadata.assert_has_calls(
+            [
+                call(mock_get_latest_dataset_metadata.return_value),
+                call(mock_get_latest_dataset_metadata.return_value),
+            ]
+        )
+        self.assertEqual(
+            result,
+            (
+                [
+                    dataset_mock1.get_dataset_version_details.return_value,
+                    dataset_mock2.get_dataset_version_details.return_value,
+                ],
+                [dataset_mock1.dataset_id, dataset_mock2.dataset_id],
+            ),
+        )
+
+    @patch("dafni_cli.commands.delete.click")
+    def test_first_dataset_version_with_permissions_but_second_without_exits_and_shows_dataset_without_permissions(
+        self, mock_click, mock_parse_dataset_metadata, mock_get_latest_dataset_metadata
+    ):
+        """Tests collate_dataset_version_details works correctly for a list of
+        dataset versions where the first has delete permissions and the second
+        does not"""
+
+        # SETUP
+        session = MagicMock()
+        version_id1 = "version-id-1"
+        version_id2 = "version-id-2"
+        version_id_list = [version_id1, version_id2]
+
+        dataset_mock1 = MagicMock()
+        dataset_mock1.dataset_id = "dataset-id-1"
+        dataset_mock1.auth.destroy = True
+        dataset_mock2 = MagicMock()
+        dataset_mock2.dataset_id = "dataset-id-2"
+        dataset_mock2.auth.destroy = False
+
+        mock_parse_dataset_metadata.side_effect = [dataset_mock1, dataset_mock2]
+
+        # CALL
+        with self.assertRaises(SystemExit):
+            delete.collate_dataset_version_details(session, version_id_list)
+
+        # ASSERT
+        mock_get_latest_dataset_metadata.assert_has_calls(
+            [call(session, version_id1), call(session, version_id2)]
+        )
+        mock_parse_dataset_metadata.assert_has_calls(
+            [
+                call(mock_get_latest_dataset_metadata.return_value),
+                call(mock_get_latest_dataset_metadata.return_value),
+            ]
+        )
+        self.assertEqual(
+            mock_click.echo.call_args_list,
+            [
+                call(
+                    "You do not have sufficient permissions to delete dataset version:"
+                ),
+                call(dataset_mock2.get_dataset_version_details.return_value),
+            ],
+        )
+
+
 @patch("dafni_cli.commands.delete.get_workflow")
 @patch("dafni_cli.commands.delete.parse_workflow")
 class TestCollateWorkflowVersionDetails(TestCase):
-    """Test class to collate_workflow_version_details function"""
+    """Test class to test the collate_workflow_version_details function"""
 
     def test_single_workflow_with_valid_permissions_returns_single_model_details(
         self, mock_parse_workflow, mock_get_workflow
@@ -471,7 +638,7 @@ class TestDelete(TestCase):
         self.assertEqual(ctx["session"], session)
         self.assertEqual(result.exit_code, 0)
 
-    # ----------------- MODELS
+    # ----------------- MODEL
 
     @patch("dafni_cli.commands.delete.collate_model_version_details")
     @patch("dafni_cli.commands.delete.delete_model")
@@ -572,7 +739,7 @@ class TestDelete(TestCase):
         )
         self.assertEqual(result.exit_code, 1)
 
-    # ----------------- DATASETS
+    # ----------------- DATASET
 
     @patch("dafni_cli.commands.delete.collate_dataset_details")
     @patch("dafni_cli.commands.delete.delete_dataset")
@@ -586,10 +753,11 @@ class TestDelete(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         ctx = {}
+        dataset_ids = ("dataset-id",)
         version_ids = ("version-id",)
         mock_collate_dataset_details.return_value = (
             ["Dataset 1 details"],
-            list(version_ids),
+            list(dataset_ids),
         )
 
         # CALL
@@ -600,7 +768,7 @@ class TestDelete(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_collate_dataset_details.assert_called_once_with(session, version_ids)
-        mock_delete_dataset.assert_called_with(session, version_ids[0])
+        mock_delete_dataset.assert_called_with(session, dataset_ids[0])
 
         self.assertEqual(
             result.output,
@@ -620,13 +788,14 @@ class TestDelete(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         ctx = {}
+        dataset_ids = ("dataset-id-1", "dataset-id-1")
         version_ids = ("version-id-1", "version-id-2")
         mock_collate_dataset_details.return_value = (
             [
                 "Dataset 1 details",
                 "Dataset 2 details",
             ],
-            list(version_ids),
+            list(dataset_ids),
         )
 
         # CALL
@@ -639,7 +808,7 @@ class TestDelete(TestCase):
         mock_collate_dataset_details.assert_called_once_with(session, version_ids)
         self.assertEqual(
             mock_delete_dataset.call_args_list,
-            [call(session, version_ids[0]), call(session, version_ids[1])],
+            [call(session, dataset_ids[0]), call(session, dataset_ids[1])],
         )
 
         self.assertEqual(
@@ -660,10 +829,11 @@ class TestDelete(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         ctx = {}
+        dataset_ids = ("dataset-id",)
         version_ids = ("version-id",)
         mock_collate_dataset_details.return_value = (
             ["Dataset 1 details"],
-            list(version_ids),
+            list(dataset_ids),
         )
 
         # CALL
@@ -682,7 +852,140 @@ class TestDelete(TestCase):
         )
         self.assertEqual(result.exit_code, 1)
 
-    # ----------------- WORKFLOWS
+    # ----------------- DATASET VERSION
+
+    @patch("dafni_cli.commands.delete.collate_dataset_version_details")
+    @patch("dafni_cli.commands.delete.delete_dataset_version")
+    def test_delete_dataset_version(
+        self,
+        mock_delete_dataset_version,
+        mock_collate_dataset_version_details,
+        mock_DAFNISession,
+    ):
+        """Tests that the 'delete dataset-version' command works correctly
+        with a single version id"""
+        # SETUP
+        session = MagicMock()
+        mock_DAFNISession.return_value = session
+        runner = CliRunner()
+        ctx = {}
+        dataset_ids = ("dataset-id",)
+        version_ids = ("version-id",)
+        mock_collate_dataset_version_details.return_value = (
+            ["Dataset 1 details"],
+            list(dataset_ids),
+        )
+
+        # CALL
+        result = runner.invoke(
+            delete.delete, ["dataset-version"] + list(version_ids), input="y", obj=ctx
+        )
+
+        # ASSERT
+        mock_DAFNISession.assert_called_once()
+        mock_collate_dataset_version_details.assert_called_once_with(
+            session, version_ids
+        )
+        mock_delete_dataset_version.assert_called_with(
+            session, dataset_id=dataset_ids[0], version_id=version_ids[0]
+        )
+
+        self.assertEqual(
+            result.output,
+            "Dataset 1 details\nConfirm deletion of dataset versions? [y/N]: y\nDataset versions deleted\n",
+        )
+        self.assertEqual(result.exit_code, 0)
+
+    @patch("dafni_cli.commands.delete.collate_dataset_version_details")
+    @patch("dafni_cli.commands.delete.delete_dataset_version")
+    def test_delete_dataset_version_multiple(
+        self,
+        mock_delete_dataset_version,
+        mock_collate_dataset_version_details,
+        mock_DAFNISession,
+    ):
+        """Tests that the 'delete dataset-version' command works correctly
+        with multiple version ids"""
+        # SETUP
+        session = MagicMock()
+        mock_DAFNISession.return_value = session
+        runner = CliRunner()
+        ctx = {}
+        dataset_ids = ("dataset-id-1", "dataset-id-1")
+        version_ids = ("version-id-1", "version-id-2")
+        mock_collate_dataset_version_details.return_value = (
+            [
+                "Dataset 1 details",
+                "Dataset 2 details",
+            ],
+            list(dataset_ids),
+        )
+
+        # CALL
+        result = runner.invoke(
+            delete.delete, ["dataset-version"] + list(version_ids), input="y", obj=ctx
+        )
+
+        # ASSERT
+        mock_DAFNISession.assert_called_once()
+        mock_collate_dataset_version_details.assert_called_once_with(
+            session, version_ids
+        )
+        self.assertEqual(
+            mock_delete_dataset_version.call_args_list,
+            [
+                call(session, dataset_id=dataset_ids[0], version_id=version_ids[0]),
+                call(session, dataset_id=dataset_ids[1], version_id=version_ids[1]),
+            ],
+        )
+
+        self.assertEqual(
+            result.output,
+            "Dataset 1 details\nDataset 2 details\nConfirm deletion of dataset versions? [y/N]: y\nDataset versions deleted\n",
+        )
+        self.assertEqual(result.exit_code, 0)
+
+    @patch("dafni_cli.commands.delete.collate_dataset_version_details")
+    @patch("dafni_cli.commands.delete.delete_dataset_version")
+    def test_delete_dataset_version_cancels_when_requested(
+        self,
+        mock_delete_dataset_version,
+        mock_collate_dataset_version_details,
+        mock_DAFNISession,
+    ):
+        """Tests that the 'delete dataset-version' can be canceled after
+        printing the dataset version info"""
+        # SETUP
+        session = MagicMock()
+        mock_DAFNISession.return_value = session
+        runner = CliRunner()
+        ctx = {}
+        dataset_ids = ("dataset-id",)
+        version_ids = ("version-id",)
+        mock_collate_dataset_version_details.return_value = (
+            ["Dataset 1 details"],
+            list(dataset_ids),
+        )
+
+        # CALL
+        result = runner.invoke(
+            delete.delete, ["dataset-version"] + list(version_ids), input="n", obj=ctx
+        )
+
+        # ASSERT
+        mock_DAFNISession.assert_called_once()
+        mock_collate_dataset_version_details.assert_called_once_with(
+            session, version_ids
+        )
+        mock_delete_dataset_version.assert_not_called()
+
+        self.assertEqual(
+            result.output,
+            "Dataset 1 details\nConfirm deletion of dataset versions? [y/N]: n\nAborted!\n",
+        )
+        self.assertEqual(result.exit_code, 1)
+
+    # ----------------- WORKFLOW
 
     @patch("dafni_cli.commands.delete.collate_workflow_version_details")
     @patch("dafni_cli.commands.delete.delete_workflow")

--- a/test/datasets/test_dataset_metadata.py
+++ b/test/datasets/test_dataset_metadata.py
@@ -691,7 +691,7 @@ class TestDatasetMetadataTestCase(TestCase):
         )
 
     def test_get_dataset_details(self):
-        """Tests test_output_version_details functions as expected"""
+        """Tests test_get_dataset_details functions as expected"""
         # SETUP
         dataset_metadata: DatasetMetadata = parse_dataset_metadata(
             TEST_DATASET_METADATA
@@ -705,11 +705,30 @@ class TestDatasetMetadataTestCase(TestCase):
             result,
             f"Title: {dataset_metadata.title}\n"
             f"ID: {dataset_metadata.dataset_id}\n"
-            f"Latest version: {dataset_metadata.version_id}\n"
+            f"Created: {format_datetime(dataset_metadata.created, include_time=True)}\n"
             f"Publisher: {dataset_metadata.publisher.name}\n"
             f"Version IDs:\n"
             f"{dataset_metadata.version_history.versions[0].version_id}\n"
             f"{dataset_metadata.version_history.versions[1].version_id}\n",
+        )
+
+    def test_get_dataset_version_details(self):
+        """Tests test_get_dataset_version_details functions as expected"""
+        # SETUP
+        dataset_metadata: DatasetMetadata = parse_dataset_metadata(
+            TEST_DATASET_METADATA
+        )
+
+        # CALL
+        result = dataset_metadata.get_dataset_version_details()
+
+        # ASSERT
+        self.assertEqual(
+            result,
+            f"Title: {dataset_metadata.title}\n"
+            f"Version ID: {dataset_metadata.version_id}\n"
+            f"Created: {format_datetime(dataset_metadata.created, include_time=True)}\n"
+            f"Publisher: {dataset_metadata.publisher.name}\n",
         )
 
     @patch.object(DataFile, "download_contents")


### PR DESCRIPTION
Adds a `dafni delete dataset-version` command.

![image](https://github.com/dafnifacility/cli/assets/90245114/5934592c-cf5e-4d96-9816-79efb1b4e7da)

Also removes the "Latest version" property from output of get dataset as this was incorrect - it just reported whatever version the user entered.