### PR TITLE
feat: Add text searching for 'get workflows' [CORE-2739]

### DIFF
--- a/dafni_cli/commands/get.py
+++ b/dafni_cli/commands/get.py
@@ -331,6 +331,7 @@ def workflows(
     workflow_dict_list = get_all_workflows(ctx.obj["session"])
     workflow_list = parse_workflows(workflow_dict_list)
 
+    # Apply filtering
     filters = []
     if search:
         filters.append(workflow_text_filter(search))
@@ -342,6 +343,8 @@ def workflows(
     filtered_workflows, filtered_workflow_dicts = filter_multiple(
         filters, workflow_list, workflow_dict_list
     )
+
+    # Output
     if json:
         print_json(filtered_workflow_dicts)
     else:

--- a/dafni_cli/commands/get.py
+++ b/dafni_cli/commands/get.py
@@ -12,6 +12,12 @@ from dafni_cli.consts import DATE_INPUT_FORMAT, DATE_INPUT_FORMAT_VERBOSE
 from dafni_cli.datasets import dataset_filtering
 from dafni_cli.datasets.dataset import parse_datasets
 from dafni_cli.datasets.dataset_metadata import parse_dataset_metadata
+from dafni_cli.filtering import (
+    creation_date_filter,
+    filter_multiple,
+    publication_date_filter,
+    workflow_text_filter,
+)
 from dafni_cli.models.model import parse_model, parse_models
 from dafni_cli.utils import print_json
 from dafni_cli.workflows.workflow import parse_workflow, parse_workflows
@@ -275,6 +281,12 @@ def dataset(
     type=bool,
 )
 @click.option(
+    "--search",
+    default=None,
+    help="Search text to filter by. Workflows with this text in either their display name or summary will be displayed.",
+    type=str,
+)
+@click.option(
     "--creation-date",
     default=None,
     help=f"Filter for workflows created since given date. Format: {DATE_INPUT_FORMAT_VERBOSE}",
@@ -295,7 +307,12 @@ def dataset(
 )
 @click.pass_context
 def workflows(
-    ctx: Context, long: bool, creation_date: str, publication_date: str, json: bool
+    ctx: Context,
+    long: bool,
+    search: Optional[str],
+    creation_date: Optional[str],
+    publication_date: Optional[str],
+    json: bool,
 ):
     """
     Display attributes of all workflows. Options allow more details to be listed,
@@ -304,29 +321,32 @@ def workflows(
     Args:
         ctx (context): contains user session for authentication
         long (bool): whether to print the description of each model as well
-        creation_date (str): for filtering by creation date. Format:
-                             DATE_INPUT_FORMAT_VERBOSE
-        publication_date (str): for filtering by publication date. Format:
-                                DATE_INPUT_FORMAT_VERBOSE
+        search (Optional[str]): Search text to filter workflows by
+        creation_date (Optional[str]): for filtering by creation date. Format:
+                                       DATE_INPUT_FORMAT_VERBOSE
+        publication_date (Optional[str]): for filtering by publication date. Format:
+                                          DATE_INPUT_FORMAT_VERBOSE
         json (bool): whether to print the raw json returned by the DAFNI API
     """
     workflow_dict_list = get_all_workflows(ctx.obj["session"])
     workflow_list = parse_workflows(workflow_dict_list)
 
-    filtered_workflow_dict_list = []
-    for workflow_inst, workflow_dict in zip(workflow_list, workflow_dict_list):
-        date_filter = True
-        if creation_date:
-            date_filter = workflow_inst.filter_by_date("creation", creation_date)
-        if publication_date:
-            date_filter = workflow_inst.filter_by_date("publication", publication_date)
-        if date_filter:
-            if json:
-                filtered_workflow_dict_list.append(workflow_dict)
-            else:
-                workflow_inst.output_details(long)
+    filters = []
+    if search:
+        filters.append(workflow_text_filter(search))
+    if creation_date:
+        filters.append(creation_date_filter(creation_date))
+    if publication_date:
+        filters.append(publication_date_filter(publication_date))
+
+    filtered_workflows, filtered_workflow_dicts = filter_multiple(
+        filters, workflow_list, workflow_dict_list
+    )
     if json:
-        print_json(filtered_workflow_dict_list)
+        print_json(filtered_workflow_dicts)
+    else:
+        for workflow_inst in filtered_workflows:
+            workflow_inst.output_details(long)
 
 
 @get.command(

--- a/dafni_cli/filtering.py
+++ b/dafni_cli/filtering.py
@@ -9,7 +9,7 @@ def filter_multiple(
     filters: List[Callable[[Any], bool]], instances: List[Any], dictionaries: List[dict]
 ) -> List[Any]:
     """Filters a list of objects given a list of functions that must all return
-    true
+    True
 
     Args:
         filters (List[Callable[[Any], bool]]): List of filters that each
@@ -48,7 +48,7 @@ def creation_date_filter(
                         filter. (Only the date part will be used)
     Returns:
         Callable[[Union[Model, Workflow]], bool]: Filter function to use with
-                                                filter_multiple
+                                                  filter_multiple
     """
 
     def filter_creation_date(value: Union[Model, Workflow]) -> bool:

--- a/dafni_cli/filtering.py
+++ b/dafni_cli/filtering.py
@@ -16,10 +16,16 @@ def filter_multiple(
                  receive a value from the list and should return true
                  if that value should be in the filtered list or false
                  otherwise.
-        values (List[Any]): List of values to filter
+        instances (List[Any]): List of parsed DAFNI object instances e.g.
+                               Workflow's These will be passed to the filters.
+        dictionaries (List[dict]): List of dictionaries that were parsed into
+                                   the instances. Ensures filtering can be
+                                   applied for commands using --json.
 
     Returns:
-        List[Any]: The filtered list of values
+        List[Any]: Filtered list of DAFNI object instances
+        List[dict]: Filtered list of dictionaries corresponding to the
+                    filtered DAFNI object instances
     """
 
     # Skip filtering if unnecessary

--- a/dafni_cli/filtering.py
+++ b/dafni_cli/filtering.py
@@ -1,0 +1,105 @@
+from datetime import datetime
+from typing import Any, Callable, List, Union
+
+from dafni_cli.models.model import Model
+from dafni_cli.workflows.workflow import Workflow
+
+
+def filter_multiple(
+    filters: List[Callable[[Any], bool]], instances: List[Any], dictionaries: List[dict]
+) -> List[Any]:
+    """Filters a list of objects given a list of functions that must all return
+    true
+
+    Args:
+        filters (List[Callable[[Any], bool]]): List of filters that each
+                 receive a value from the list and should return true
+                 if that value should be in the filtered list or false
+                 otherwise.
+        values (List[Any]): List of values to filter
+
+    Returns:
+        List[Any]: The filtered list of values
+    """
+
+    # Skip filtering if unnecessary
+    if len(filters) == 0:
+        return instances, dictionaries
+
+    filtered_instances = []
+    filtered_dictionaries = []
+    for instance, dictionary in zip(instances, dictionaries):
+        if all(filter_func(instance) for filter_func in filters):
+            filtered_instances.append(instance)
+            filtered_dictionaries.append(dictionary)
+    return filtered_instances, filtered_dictionaries
+
+
+# Methods to create filters for use with DAFNI objects
+def creation_date_filter(
+    oldest_creation_date: datetime,
+) -> Callable[[Union[Model, Workflow]], bool]:
+    """Returns a filter for filtering models or workflows by their creation
+    date
+
+    Args:
+        oldest_creation_date (datetime): Creation date to filter by. All
+                        objects with a date after this will be returned by the
+                        filter. (Only the date part will be used)
+    Returns:
+        Callable[[Union[Model, Workflow]], bool]: Filter function to use with
+                                                filter_multiple
+    """
+
+    def filter_creation_date(value: Union[Model, Workflow]) -> bool:
+        return value.creation_date.date() >= oldest_creation_date.date()
+
+    return filter_creation_date
+
+
+def publication_date_filter(
+    oldest_publication_date: datetime,
+) -> Callable[[Union[Model, Workflow]], bool]:
+    """Returns a filter for filtering models or workflows by their creation
+    date
+
+    Args:
+        oldest_creation_date (datetime): Creation date to filter by. All
+                        objects with a date after this will be returned by the
+                        filter. (Only the date part will be used)
+    Returns:
+        Callable[[Union[Model, Workflow]], bool]: Filter function to use with
+                                                  filter_multiple
+    """
+
+    def filter_publication_date(value: Union[Model, Workflow]) -> bool:
+        return value.publication_date.date() >= oldest_publication_date.date()
+
+    return filter_publication_date
+
+
+def workflow_text_filter(
+    text: str,
+) -> Callable[[Workflow], bool]:
+    """Returns a filter for filtering workflows by some search text
+
+    All workflows whose display name or summary contains the search text will
+    be returned by the filter. Case is ignored (as in frontend).
+
+    Args:
+        text (str): Search text to filter by. All workflows with the search
+                    text in either the display name or summary will be
+                    returned by the filter.
+    Returns:
+        Callable[[Workflow], bool]: Filter function to use with
+                                    filter_multiple
+    """
+    text = text.lower()
+
+    def filter_text(value: Workflow) -> bool:
+        return (
+            text in value.metadata.display_name.lower()
+            or text in value.metadata.summary.lower()
+        )
+
+    return filter_text

--- a/dafni_cli/workflows/workflow.py
+++ b/dafni_cli/workflows/workflow.py
@@ -195,27 +195,6 @@ class Workflow(ParserBaseObject):
         )
         return self._metadata
 
-    # TODO: Unify with Model
-    def filter_by_date(self, key: str, date: datetime) -> bool:
-        """Returns whether a particular date is less than or equal to the
-           creation/publication date of this workflow.
-
-        Args:
-            key (str): Key for which date to check must be either 'creation'
-                       or 'publication'
-            date (datetime): Datetime object (only the date will be used)
-
-        Returns:
-            bool: Whether the given date is less than or equal to the
-                  chosen date
-        """
-        date_val = date.date()
-        if key.lower() == "creation":
-            return self.creation_date.date() >= date_val
-        if key.lower() == "publication":
-            return self.publication_date.date() >= date_val
-        raise KeyError("Key should be 'creation' or 'publication'")
-
     def output_details(self, long: bool = False):
         """Prints relevant workflow attributes to command line
 

--- a/test/commands/test_get.py
+++ b/test/commands/test_get.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from unittest import TestCase
 from unittest.mock import ANY, MagicMock, patch
 
@@ -5,6 +6,7 @@ from click.testing import CliRunner
 
 from dafni_cli.api.exceptions import ResourceNotFoundError
 from dafni_cli.commands import get
+from dafni_cli.consts import DATE_INPUT_FORMAT
 
 from test.fixtures.dataset_metadata import TEST_DATASET_METADATA
 
@@ -773,110 +775,127 @@ class TestGetDataset(TestCase):
         self.assertEqual(result.exit_code, 0)
 
 
-@patch("dafni_cli.commands.get.DAFNISession")
-@patch("dafni_cli.commands.get.get_all_workflows")
-@patch("dafni_cli.commands.get.parse_workflows")
-@patch("dafni_cli.commands.get.print_json")
 class TestGetWorkflows(TestCase):
     """Test class to test the get workflows command"""
 
-    def test_get_workflows(
+    def setUp(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
-    ):
+    ) -> None:
+        super().setUp()
+
+        self.mock_DAFNISession = patch("dafni_cli.commands.get.DAFNISession").start()
+        self.mock_get_all_workflows = patch(
+            "dafni_cli.commands.get.get_all_workflows"
+        ).start()
+        self.mock_parse_workflows = patch(
+            "dafni_cli.commands.get.parse_workflows"
+        ).start()
+        self.mock_print_json = patch("dafni_cli.commands.get.print_json").start()
+        self.mock_workflow_text_filter = patch(
+            "dafni_cli.commands.get.workflow_text_filter"
+        ).start()
+        self.mock_creation_date_filter = patch(
+            "dafni_cli.commands.get.creation_date_filter"
+        ).start()
+        self.mock_publication_date_filter = patch(
+            "dafni_cli.commands.get.publication_date_filter"
+        ).start()
+        self.mock_filter_multiple = patch(
+            "dafni_cli.commands.get.filter_multiple"
+        ).start()
+
+        self.addCleanup(patch.stopall)
+
+    def test_get_workflows(self):
         """Tests that the 'get workflows' command works correctly (with no
         optional arguments)"""
 
         # SETUP
         session = MagicMock()
-        mock_DAFNISession.return_value = session
+        self.mock_DAFNISession.return_value = session
         runner = CliRunner()
+        workflow_dicts = [MagicMock(), MagicMock()]
         workflows = [MagicMock(), MagicMock()]
-        mock_get_all_workflows.return_value = workflows
-        mock_parse_workflows.return_value = workflows
+        self.mock_get_all_workflows.return_value = workflows
+        self.mock_parse_workflows.return_value = workflows
+
+        # No filtering
+        self.mock_filter_multiple.return_value = workflows, workflow_dicts
 
         # CALL
         result = runner.invoke(get.get, ["workflows"])
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_get_all_workflows.assert_called_with(session)
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_get_all_workflows.assert_called_with(session)
         for workflow in workflows:
             workflow.output_details.assert_called_with(False)
-        mock_print_json.assert_not_called()
+        self.mock_print_json.assert_not_called()
 
         self.assertEqual(result.exit_code, 0)
 
-    def test_get_workflows_with_long_true(
-        self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
-    ):
+    def test_get_workflows_with_long_true(self):
         """Tests that the 'get workflows' command works correctly (with long
         True)"""
 
         # SETUP
         session = MagicMock()
-        mock_DAFNISession.return_value = session
+        self.mock_DAFNISession.return_value = session
         runner = CliRunner()
+        workflow_dicts = [MagicMock(), MagicMock()]
         workflows = [MagicMock(), MagicMock()]
-        mock_get_all_workflows.return_value = workflows
-        mock_parse_workflows.return_value = workflows
+        self.mock_get_all_workflows.return_value = workflow_dicts
+        self.mock_parse_workflows.return_value = workflows
+
+        # No filtering
+        self.mock_filter_multiple.return_value = workflows, workflow_dicts
 
         # CALL
         result = runner.invoke(get.get, ["workflows", "--long"])
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_get_all_workflows.assert_called_with(session)
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_get_all_workflows.assert_called_with(session)
         for workflow in workflows:
             workflow.output_details.assert_called_with(True)
-        mock_print_json.assert_not_called()
+        self.mock_print_json.assert_not_called()
 
         self.assertEqual(result.exit_code, 0)
 
     def test_get_workflows_with_json_true(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
     ):
         """Tests that the 'get workflows' command works correctly (with json
         True)"""
 
         # SETUP
         session = MagicMock()
-        mock_DAFNISession.return_value = session
+        self.mock_DAFNISession.return_value = session
         runner = CliRunner()
+        workflow_dicts = [MagicMock(), MagicMock()]
         workflows = [MagicMock(), MagicMock()]
-        mock_get_all_workflows.return_value = workflows
-        mock_parse_workflows.return_value = workflows
+        self.mock_get_all_workflows.return_value = workflow_dicts
+        self.mock_parse_workflows.return_value = workflows
+
+        # No filtering
+        self.mock_filter_multiple.return_value = workflows, workflow_dicts
 
         # CALL
         result = runner.invoke(get.get, ["workflows", "--json"])
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_get_all_workflows.assert_called_with(session)
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_get_all_workflows.assert_called_with(session)
         for workflow in workflows:
             workflow.output_details.assert_not_called()
-        mock_print_json.assert_called_with(workflows)
+        self.mock_print_json.assert_called_with(workflow_dicts)
 
         self.assertEqual(result.exit_code, 0)
 
     def _test_get_workflows_with_date_filter(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
         date_filter_options,
+        mock_date_filter,
         long,
     ):
         """Helper method for testing that the 'get workflows' command works
@@ -884,181 +903,153 @@ class TestGetWorkflows(TestCase):
 
         # SETUP
         session = MagicMock()
-        mock_DAFNISession.return_value = session
+        self.mock_DAFNISession.return_value = session
         runner = CliRunner()
+        workflow_dicts = [MagicMock(), MagicMock()]
         workflows = [MagicMock(), MagicMock()]
+        date = datetime(2023, 1, 1)
+
+        self.mock_get_all_workflows.return_value = workflow_dicts
+        self.mock_parse_workflows.return_value = workflows
 
         # Make the first model filter but the second not
-        workflows[0].filter_by_date = MagicMock(return_value=True)
-        workflows[1].filter_by_date = MagicMock(return_value=False)
-
-        mock_get_all_workflows.return_value = workflows
-        mock_parse_workflows.return_value = workflows
+        self.mock_filter_multiple.return_value = [workflows[0]], [workflow_dicts[0]]
 
         # CALL
-        options = ["workflows", date_filter_options[0], "2023-01-01"]
+        options = [
+            "workflows",
+            date_filter_options[0],
+            date.strftime(DATE_INPUT_FORMAT),
+        ]
         if long:
             options.append("--long")
         result = runner.invoke(get.get, options)
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_get_all_workflows.assert_called_with(session)
-        workflows[0].filter_by_date.assert_called_with(date_filter_options[1], ANY)
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_get_all_workflows.assert_called_with(session)
+        mock_date_filter.assert_called_once_with(date)
+        self.mock_filter_multiple.assert_called_with(
+            [mock_date_filter.return_value], workflows, workflow_dicts
+        )
+
         workflows[0].output_details.assert_called_with(long)
         workflows[1].output_details.assert_not_called()
-        mock_print_json.assert_not_called()
+        self.mock_print_json.assert_not_called()
 
         self.assertEqual(result.exit_code, 0)
 
     def test_get_workflows_with_creation_date_filter(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
     ):
         """Tests that the 'get workflows' command works correctly (while
         filtering by creation date)"""
 
         self._test_get_workflows_with_date_filter(
-            mock_print_json,
-            mock_parse_workflows,
-            mock_get_all_workflows,
-            mock_DAFNISession,
             ("--creation-date", "creation"),
+            self.mock_creation_date_filter,
             False,
         )
 
     def test_get_workflows_with_publication_date_filter(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
     ):
         """Tests that the 'get workflows' command works correctly (while
         filtering by publication date)"""
 
         self._test_get_workflows_with_date_filter(
-            mock_print_json,
-            mock_parse_workflows,
-            mock_get_all_workflows,
-            mock_DAFNISession,
             ("--publication-date", "publication"),
+            self.mock_publication_date_filter,
             False,
         )
 
     def test_get_workflows_with_creation_date_filter_and_long_true(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
     ):
         """Tests that the 'get workflows' command works correctly (while
         filtering by creation date and long=True)"""
 
         self._test_get_workflows_with_date_filter(
-            mock_print_json,
-            mock_parse_workflows,
-            mock_get_all_workflows,
-            mock_DAFNISession,
             ("--creation-date", "creation"),
+            self.mock_creation_date_filter,
             True,
         )
 
     def test_get_workflows_with_publication_date_filter_and_long_true(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
     ):
         """Tests that the 'get workflows' command works correctly (while
         filtering by publication date and long=True)"""
 
         self._test_get_workflows_with_date_filter(
-            mock_print_json,
-            mock_parse_workflows,
-            mock_get_all_workflows,
-            mock_DAFNISession,
             ("--publication-date", "publication"),
+            self.mock_publication_date_filter,
             True,
         )
 
     def _test_get_workflows_with_date_filter_json(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
         date_filter_options,
+        mock_date_filter,
     ):
         """Helper method for testing that the 'get workflows' command works
         correctly with the given date filters and the --json flag"""
 
         # SETUP
         session = MagicMock()
-        mock_DAFNISession.return_value = session
+        self.mock_DAFNISession.return_value = session
         runner = CliRunner()
+        workflow_dicts = [MagicMock(), MagicMock()]
         workflows = [MagicMock(), MagicMock()]
+        date = datetime(2023, 1, 1)
+
+        self.mock_get_all_workflows.return_value = workflow_dicts
+        self.mock_parse_workflows.return_value = workflows
 
         # Make the first model filter but the second not
-        workflows[0].filter_by_date = MagicMock(return_value=True)
-        workflows[1].filter_by_date = MagicMock(return_value=False)
-
-        mock_get_all_workflows.return_value = workflows
-        mock_parse_workflows.return_value = workflows
+        self.mock_filter_multiple.return_value = [workflows[0]], [workflow_dicts[0]]
 
         # CALL
-        options = ["workflows", date_filter_options[0], "2023-01-01", "--json"]
+        options = [
+            "workflows",
+            date_filter_options[0],
+            date.strftime(DATE_INPUT_FORMAT),
+            "--json",
+        ]
         result = runner.invoke(get.get, options)
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_get_all_workflows.assert_called_with(session)
-        workflows[0].filter_by_date.assert_called_with(date_filter_options[1], ANY)
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_get_all_workflows.assert_called_with(session)
+        mock_date_filter.assert_called_once_with(date)
+        self.mock_filter_multiple.assert_called_with(
+            [mock_date_filter.return_value], workflows, workflow_dicts
+        )
         workflows[0].output_details.assert_not_called()
         workflows[1].output_details.assert_not_called()
-        mock_print_json.assert_called_with([workflows[0]])
+        self.mock_print_json.assert_called_with([workflow_dicts[0]])
 
         self.assertEqual(result.exit_code, 0)
 
     def test_get_workflows_with_creation_date_filter_json(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
     ):
         """Tests that the 'get workflows' command works correctly (while
         filtering by creation date and printing json)"""
 
         self._test_get_workflows_with_date_filter_json(
-            mock_print_json,
-            mock_parse_workflows,
-            mock_get_all_workflows,
-            mock_DAFNISession,
             ("--creation-date", "creation"),
+            self.mock_creation_date_filter,
         )
 
     def test_get_workflows_with_publication_date_filter_json(
         self,
-        mock_print_json,
-        mock_parse_workflows,
-        mock_get_all_workflows,
-        mock_DAFNISession,
     ):
         """Tests that the 'get workflows' command works correctly (while
         filtering by publication date and printing json)"""
 
         self._test_get_workflows_with_date_filter_json(
-            mock_print_json,
-            mock_parse_workflows,
-            mock_get_all_workflows,
-            mock_DAFNISession,
-            ("--publication-date", "publication"),
+            ("--publication-date", "publication"), self.mock_publication_date_filter
         )
 
 

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -1,0 +1,201 @@
+from dataclasses import dataclass
+from datetime import datetime
+from unittest import TestCase
+
+from mock import MagicMock
+
+from dafni_cli import filtering
+
+
+@dataclass
+class TestWorkflowMetadata:
+    """Dataclass storing only the metadata needed for testing workflow
+    filtering"""
+
+    display_name: str
+    summary: str
+
+
+@dataclass
+class TestDataclass:
+    """Simple dataclass for representing some test instances to pass
+    to the function"""
+
+    name: str
+    description: str
+    creation_date: datetime
+    publication_date: datetime
+    metadata: TestWorkflowMetadata
+
+
+class TestFiltering(TestCase):
+    """Tests that the functions within filtering.py work correctly"""
+
+    # Some test data
+    TEST_INSTANCES = [
+        TestDataclass(
+            "Value1",
+            "Description of object 1",
+            datetime(2022, 1, 12),
+            datetime(2022, 2, 12),
+            TestWorkflowMetadata("Display name 1", "Simple summary 1"),
+        ),
+        TestDataclass(
+            "Value2",
+            "Something completely different",
+            datetime(2022, 8, 1),
+            datetime(2022, 9, 1),
+            TestWorkflowMetadata("Display name 2 test", "Simple summary 2"),
+        ),
+        TestDataclass(
+            "Value3",
+            "Description of object 3",
+            datetime(2023, 6, 21),
+            datetime(2023, 7, 21),
+            TestWorkflowMetadata("Display name 3", "Simple summary 3 test"),
+        ),
+    ]
+
+    TEST_DICTIONARIES = [MagicMock(), MagicMock(), MagicMock()]
+
+    def test_filter_multiple_with_no_filters(self):
+        """Tests filter_multiple does nothing when not given any filters"""
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [], self.TEST_INSTANCES, self.TEST_DICTIONARIES
+        )
+
+        # ASSERT
+        self.assertEqual(filtered_instances, self.TEST_INSTANCES)
+        self.assertEqual(filtered_dictionaries, self.TEST_DICTIONARIES)
+
+    def test_filter_multiple_with_single_filter(self):
+        """Tests filter_multiple works correctly when given a single filter"""
+
+        # SETUP
+        # Simple filter to select only the second value
+        def simple_filter(instance: TestDataclass):
+            return instance.name == "Value2"
+
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [simple_filter], self.TEST_INSTANCES, self.TEST_DICTIONARIES
+        )
+
+        # ASSERT
+        self.assertEqual(filtered_instances, [self.TEST_INSTANCES[1]])
+        self.assertEqual(filtered_dictionaries, [self.TEST_DICTIONARIES[1]])
+
+    def test_with_filter_multiple_with_multiple_filters(self):
+        """Tests filter_multiple works correctly when given multiple filters"""
+
+        # SETUP
+        def filter1(instance: TestDataclass):
+            return "Description" in instance.description
+
+        def filter2(instance: TestDataclass):
+            return "object" in instance.description
+
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [filter1, filter2], self.TEST_INSTANCES, self.TEST_DICTIONARIES
+        )
+
+        # ASSERT
+        self.assertEqual(
+            filtered_instances, [self.TEST_INSTANCES[0], self.TEST_INSTANCES[2]]
+        )
+        self.assertEqual(
+            filtered_dictionaries,
+            [self.TEST_DICTIONARIES[0], self.TEST_DICTIONARIES[2]],
+        )
+
+    def test_creation_date_filter(self):
+        """Tests creation_date_filter works correctly"""
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [filtering.creation_date_filter(datetime(2022, 8, 1))],
+            self.TEST_INSTANCES,
+            self.TEST_DICTIONARIES,
+        )
+
+        # ASSERT
+        self.assertEqual(
+            filtered_instances, [self.TEST_INSTANCES[1], self.TEST_INSTANCES[2]]
+        )
+        self.assertEqual(
+            filtered_dictionaries,
+            [self.TEST_DICTIONARIES[1], self.TEST_DICTIONARIES[2]],
+        )
+
+    def test_publication_date_filter(self):
+        """Tests publication_date_filter works correctly"""
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [filtering.publication_date_filter(datetime(2022, 9, 1))],
+            self.TEST_INSTANCES,
+            self.TEST_DICTIONARIES,
+        )
+
+        # ASSERT
+        self.assertEqual(
+            filtered_instances, [self.TEST_INSTANCES[1], self.TEST_INSTANCES[2]]
+        )
+        self.assertEqual(
+            filtered_dictionaries,
+            [self.TEST_DICTIONARIES[1], self.TEST_DICTIONARIES[2]],
+        )
+
+    def test_workflow_text_filter(self):
+        """Tests workflow_text_filter works correctly"""
+
+        # First a really broad filter
+
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [filtering.workflow_text_filter("Display")],
+            self.TEST_INSTANCES,
+            self.TEST_DICTIONARIES,
+        )
+
+        # ASSERT
+        self.assertEqual(filtered_instances, self.TEST_INSTANCES)
+        self.assertEqual(
+            filtered_dictionaries,
+            self.TEST_DICTIONARIES,
+        )
+
+        # Now for a specific one (also checking case insensitive)
+
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [filtering.workflow_text_filter("suMmARy 2")],
+            self.TEST_INSTANCES,
+            self.TEST_DICTIONARIES,
+        )
+
+        # ASSERT
+        self.assertEqual(filtered_instances, [self.TEST_INSTANCES[1]])
+        self.assertEqual(
+            filtered_dictionaries,
+            [self.TEST_DICTIONARIES[1]],
+        )
+
+        # Now ensure both the display name and summary are filtered at the
+        # same time
+
+        # CALL
+        filtered_instances, filtered_dictionaries = filtering.filter_multiple(
+            [filtering.workflow_text_filter("test")],
+            self.TEST_INSTANCES,
+            self.TEST_DICTIONARIES,
+        )
+
+        # ASSERT
+        self.assertEqual(
+            filtered_instances, [self.TEST_INSTANCES[1], self.TEST_INSTANCES[2]]
+        )
+        self.assertEqual(
+            filtered_dictionaries,
+            [self.TEST_DICTIONARIES[1], self.TEST_DICTIONARIES[2]],
+        )

--- a/test/test_filtering.py
+++ b/test/test_filtering.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from unittest import TestCase
-
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from dafni_cli import filtering
 

--- a/test/workflows/test_workflow.py
+++ b/test/workflows/test_workflow.py
@@ -183,42 +183,6 @@ class TestWorkflow(TestCase):
             workflow.metadata.description, TEST_WORKFLOW_METADATA["description"]
         )
 
-    def _test_filter_by_date(
-        self, workflow: Workflow, key: str, date_str: str, expected_output: bool
-    ):
-        """Utility function to check a particular set of parameters to
-        filter_by_date does what is expected"""
-        self.assertEqual(workflow.filter_by_date(key, date_str), expected_output)
-
-    def test_filter_by_date(self):
-        """Tests filter_by_date works correctly"""
-        # SETUP
-        workflow = parse_workflow(TEST_WORKFLOW)
-
-        # Creation date and publication date's are:
-        # 2023-04-04T08:34:36.531809Z
-        # 2023-04-04T08:34:36.531809Z
-
-        # CALL
-
-        # Before
-        self._test_filter_by_date(workflow, "creation", datetime(2018, 5, 16), True)
-        self._test_filter_by_date(workflow, "publication", datetime(2018, 5, 16), True)
-        # Equal
-        self._test_filter_by_date(workflow, "creation", datetime(2023, 4, 4), True)
-        self._test_filter_by_date(workflow, "publication", datetime(2023, 4, 4), True)
-        # After
-        self._test_filter_by_date(workflow, "creation", datetime(2023, 4, 25), False)
-        self._test_filter_by_date(workflow, "publication", datetime(2023, 4, 25), False)
-
-    def test_filter_by_date_error(self):
-        """Tests filter_by_date raises an error if the key is wrong"""
-        # SETUP
-        workflow = parse_workflow(TEST_WORKFLOW)
-
-        with self.assertRaises(KeyError):
-            workflow.filter_by_date("key", datetime(2020, 12, 11))
-
     @patch("dafni_cli.workflows.workflow.click")
     def test_output_details(self, mock_click):
         """Tests output_details works correctly"""


### PR DESCRIPTION
Adds a new option --search to 'dafni get workflows' which filters the workflows obtained by checking if either their display name or summary contains given text. This should replicate what vuetify does in the tables on the frontend. This also replaces the existing filtering functions with new ones for workflows.