### PR TITLE
fix: Make workflow upload version message compulsory [CORE 3145]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Workflows:
 * List all workflow instances available to user
 * Filter list of available workflow instances
 * View specific workflow instance metadata
-* Create workflow (using workflow definition file) - BROKEN
+* Create workflow (using workflow definition file) - DONE
 * Edit workflow env params and create new workflow
 * Edit workflow data slots and create new workflow
 

--- a/dafni_cli/api/workflows_api.py
+++ b/dafni_cli/api/workflows_api.py
@@ -60,30 +60,28 @@ def get_workflow(session: DAFNISession, version_id: str) -> dict:
 def upload_workflow(
     session: DAFNISession,
     file_path: Path,
-    version_message: Optional[str] = None,
+    version_message: str,
     parent_id: Optional[str] = None,
-) -> Tuple[str, dict]:
+) -> dict:
     """Uploads a DAFNI workflow specified in a JSON file
 
     Args:
         session (DAFNISession): User session
         file_path: Path to the workflow definition file (JSON)
-        version_message: String describing the new version, which will overwrite any version message in the JSON description
+        version_message: String describing the new version
         parent_id: The ID of the parent workflow, for updating an existing workflow
 
     Returns:
-        str: The ID for the upload
-        dict: The urls for the definition and image with keys "definition" and "image", respectively.
+        dict: Contains information about the uploaded workflow
     """
     if parent_id:
         url = f"{NIMS_API_URL}/workflows/{parent_id}/upload/"
     else:
         url = f"{NIMS_API_URL}/workflows/upload/"
-    with open(file_path, "r", encoding="utf-8") as f:
-        workflow_description = json.load(f)
-        if version_message:
-            workflow_description["version_message"] = version_message
-        return session.post_request(url=url, json=workflow_description)
+    with open(file_path, "r", encoding="utf-8") as file:
+        workflow_definition = json.load(file)
+        data = {"version_message": version_message, "definition": workflow_definition}
+        return session.post_request(url=url, json=data)
 
 
 def delete_workflow_version(session: DAFNISession, version_id: str) -> Response:

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -51,7 +51,7 @@ def upload(ctx: Context):
     "-m",
     nargs=1,
     required=True,
-    help="Version message that is to be uploaded with the version. Required.",
+    help="Version message that is to be uploaded with the model.",
     type=str,
 )
 @click.option(
@@ -398,10 +398,10 @@ def dataset_metadata(
     "--version-message",
     "-m",
     nargs=1,
-    required=False,
+    required=True,
     type=str,
     default=None,
-    help="Message describing this version, will override any version message that is defined in the workflow description",
+    help="Version message that is to be uploaded with the workflow.",
 )
 @click.option(
     "--parent-id",
@@ -442,6 +442,9 @@ def workflow(
     # TODO: Validate workflow definition using workflows/validate?
 
     click.echo("Uploading workflow")
-    upload_workflow(ctx.obj["session"], definition, version_message, parent_id)
+    details = upload_workflow(
+        ctx.obj["session"], definition, version_message, parent_id
+    )
 
-    click.echo("Workflow upload complete")
+    click.echo("\nUpload successful")
+    click.echo(f"Version ID: {details['id']}")

--- a/test/api/test_workflows_api.py
+++ b/test/api/test_workflows_api.py
@@ -67,53 +67,18 @@ class TestWorkflowsAPI(TestCase):
         new_callable=mock_open,
         read_data="""
         {
-            \"version_message\": \"initial version message\",
-            \"other_data\": \"other_data\"
+            \"test_data\": \"test_data\"
         }""",
     )
     def test_upload_workflow(
         self,
         open_mock,
     ):
-        """Tests that upload_workflow works as expected without a parent or
-        overridden version_message"""
+        """Tests that upload_workflow works as expected without a parent"""
         # SETUP
         session = MagicMock()
         file_path = Path("path/to/file")
-
-        # CALL
-        result = workflows_api.upload_workflow(session, file_path=file_path)
-
-        # ASSERT
-        open_mock.assert_called_once_with(file_path, "r", encoding="utf-8")
-        session.post_request.assert_called_once_with(
-            url=f"{NIMS_API_URL}/workflows/upload/",
-            json={
-                "version_message": "initial version message",
-                "other_data": "other_data",
-            },
-        )
-        self.assertEqual(result, session.post_request.return_value)
-
-    @patch(
-        "builtins.open",
-        new_callable=mock_open,
-        read_data="""
-        {
-            \"version_message\": \"initial version message\",
-            \"other_data\": \"other_data\"
-        }""",
-    )
-    def test_upload_workflow_with_overridden_version_message(
-        self,
-        open_mock,
-    ):
-        """Tests that upload_workflow works as expected with an overridden
-        version_message and no parent"""
-        # SETUP
-        session = MagicMock()
         version_message = "Version message"
-        file_path = Path("path/to/file")
 
         # CALL
         result = workflows_api.upload_workflow(
@@ -126,7 +91,9 @@ class TestWorkflowsAPI(TestCase):
             url=f"{NIMS_API_URL}/workflows/upload/",
             json={
                 "version_message": version_message,
-                "other_data": "other_data",
+                "definition": {
+                    "test_data": "test_data",
+                },
             },
         )
         self.assertEqual(result, session.post_request.return_value)
@@ -136,8 +103,7 @@ class TestWorkflowsAPI(TestCase):
         new_callable=mock_open,
         read_data="""
         {
-            \"version_message\": \"initial version message\",
-            \"other_data\": \"other_data\"
+            \"test_data\": \"test_data\"
         }""",
     )
     def test_upload_workflow_with_parent(
@@ -148,11 +114,15 @@ class TestWorkflowsAPI(TestCase):
         # SETUP
         session = MagicMock()
         file_path = Path("path/to/file")
+        version_message = "Version message"
         parent_id = "parent-id"
 
         # CALL
         result = workflows_api.upload_workflow(
-            session, file_path=file_path, parent_id=parent_id
+            session,
+            file_path=file_path,
+            version_message=version_message,
+            parent_id=parent_id,
         )
 
         # ASSERT
@@ -160,8 +130,10 @@ class TestWorkflowsAPI(TestCase):
         session.post_request.assert_called_once_with(
             url=f"{NIMS_API_URL}/workflows/{parent_id}/upload/",
             json={
-                "version_message": "initial version message",
-                "other_data": "other_data",
+                "version_message": version_message,
+                "definition": {
+                    "test_data": "test_data",
+                },
             },
         )
         self.assertEqual(result, session.post_request.return_value)

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -1088,49 +1088,9 @@ class TestUploadWorkflow(TestCase):
         session = MagicMock()
         mock_DAFNISession.return_value = session
         runner = CliRunner()
-
-        # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "workflow",
-                    "test_definition.json",
-                ],
-                input="y",
-            )
-
-        # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_workflow.assert_called_once_with(
-            session, Path("test_definition.json"), None, None
-        )
-
-        self.assertEqual(
-            result.output,
-            "Workflow definition file path: test_definition.json\n"
-            "Version message: None\n"
-            "No parent workflow: new workflow to be created\n"
-            "Confirm workflow upload? [y/N]: y\n"
-            "Uploading workflow\n"
-            "Workflow upload complete\n",
-        )
-        self.assertEqual(result.exit_code, 0)
-
-    def test_upload_workflow_with_parent_and_version_message(
-        self,
-        mock_upload_workflow,
-        mock_DAFNISession,
-    ):
-        """Tests that the 'upload workflow' command works correctly when
-        a parent and version message is given"""
-
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
+        version_message = "Initial version"
+        version_id = "version-id"
+        mock_upload_workflow.return_value = {"id": version_id}
 
         # CALL
         with runner.isolated_filesystem():
@@ -1142,7 +1102,56 @@ class TestUploadWorkflow(TestCase):
                     "workflow",
                     "test_definition.json",
                     "--version-message",
-                    "version_message",
+                    version_message,
+                ],
+                input="y",
+            )
+
+        # ASSERT
+        mock_DAFNISession.assert_called_once()
+        mock_upload_workflow.assert_called_once_with(
+            session, Path("test_definition.json"), version_message, None
+        )
+
+        self.assertEqual(
+            result.output,
+            "Workflow definition file path: test_definition.json\n"
+            f"Version message: {version_message}\n"
+            "No parent workflow: new workflow to be created\n"
+            "Confirm workflow upload? [y/N]: y\n"
+            "Uploading workflow\n"
+            "\nUpload successful\n"
+            f"Version ID: {version_id}\n",
+        )
+        self.assertEqual(result.exit_code, 0)
+
+    def test_upload_workflow_with_parent(
+        self,
+        mock_upload_workflow,
+        mock_DAFNISession,
+    ):
+        """Tests that the 'upload workflow' command works correctly when
+        a parent is given"""
+
+        # SETUP
+        session = MagicMock()
+        mock_DAFNISession.return_value = session
+        runner = CliRunner()
+        version_message = "Initial version"
+        version_id = "version-id"
+        mock_upload_workflow.return_value = {"id": version_id}
+
+        # CALL
+        with runner.isolated_filesystem():
+            with open("test_definition.json", "w", encoding="utf-8") as file:
+                file.write("test definition file")
+            result = runner.invoke(
+                upload.upload,
+                [
+                    "workflow",
+                    "test_definition.json",
+                    "--version-message",
+                    version_message,
                     "--parent-id",
                     "parent-id",
                 ],
@@ -1152,17 +1161,18 @@ class TestUploadWorkflow(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_workflow.assert_called_once_with(
-            session, Path("test_definition.json"), "version_message", "parent-id"
+            session, Path("test_definition.json"), version_message, "parent-id"
         )
 
         self.assertEqual(
             result.output,
             "Workflow definition file path: test_definition.json\n"
-            "Version message: version_message\n"
+            f"Version message: {version_message}\n"
             "Parent workflow ID: parent-id\n"
             "Confirm workflow upload? [y/N]: y\n"
             "Uploading workflow\n"
-            "Workflow upload complete\n",
+            "\nUpload successful\n"
+            f"Version ID: {version_id}\n",
         )
         self.assertEqual(result.exit_code, 0)
 
@@ -1177,6 +1187,9 @@ class TestUploadWorkflow(TestCase):
         session = MagicMock()
         mock_DAFNISession.return_value = session
         runner = CliRunner()
+        version_message = "Initial version"
+        version_id = "version-id"
+        mock_upload_workflow.return_value = {"id": version_id}
 
         # CALL
         with runner.isolated_filesystem():
@@ -1187,6 +1200,8 @@ class TestUploadWorkflow(TestCase):
                 [
                     "workflow",
                     "test_definition.json",
+                    "--version-message",
+                    version_message,
                 ],
                 input="n",
             )
@@ -1198,7 +1213,7 @@ class TestUploadWorkflow(TestCase):
         self.assertEqual(
             result.output,
             "Workflow definition file path: test_definition.json\n"
-            "Version message: None\n"
+            f"Version message: {version_message}\n"
             "No parent workflow: new workflow to be created\n"
             "Confirm workflow upload? [y/N]: n\n"
             "Aborted!\n",


### PR DESCRIPTION
Makes version message compulsory for `dafni upload workflow` and modifies it to work like `dafni upload model`, taking the definition file instead of a file containing it with a version message.

I also added an output for the created workflow's ID e.g.

![image](https://github.com/dafnifacility/cli/assets/90245114/0eada467-449d-4145-8f02-3ce380210cd2)

