### PR TITLE
feat: Add upload workflow-parameter-set command [CORE-2744]

### DIFF
--- a/dafni_cli/api/session.py
+++ b/dafni_cli/api/session.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO, Literal, Optional, Union
+from typing import BinaryIO, Callable, Literal, Optional, Union
 
 import click
 import requests
@@ -389,13 +389,24 @@ class DAFNISession:
         except requests.JSONDecodeError:
             return None
 
-    def _check_response(self, url: str, response: requests.Response):
+    def _check_response(
+        self,
+        url: str,
+        response: requests.Response,
+        error_message_func: Callable[[requests.Response], Optional[str]] = None,
+    ):
         """Checks a requests response for any errors and raises them as
         required
 
         Args:
             url (str): URL endpoint that was being queried
             response (requests.Response): Response from requests
+            error_message_func (Optional[Callable[[requests.Response], Optional[str]]]):
+                                Function called on a response after an error to
+                                obtain an error message. If it returns None, a
+                                HTTPError will be returned, otherwise it will be
+                                a DAFNIError. By default this will be
+                                get_error_message.
 
         Raises:
             EndpointNotFoundError: If the response returns a 404 status code
@@ -403,6 +414,9 @@ class DAFNISession:
             HTTPError: If any other error occurs without an error message from
                        DAFNI
         """
+
+        if error_message_func is None:
+            error_message_func = self.get_error_message
 
         error_message = None
 
@@ -414,7 +428,7 @@ class DAFNISession:
                 raise EndpointNotFoundError(f"Could not find {url}")
 
             # Attempt to find an error message from the API itself
-            error_message = self.get_error_message(response)
+            error_message = error_message_func(response)
 
         # If there is an error from DAFNI raise a DAFNI exception as well
         # with more details, otherwise leave as any errors are HTTPError's
@@ -431,6 +445,9 @@ class DAFNISession:
         content_type: str = "application/json",
         allow_redirect: bool = False,
         content: bool = False,
+        error_message_func: Optional[
+            Callable[[requests.Response], Optional[str]]
+        ] = None,
     ):
         """Performs a GET request from the DAFNI API
 
@@ -447,6 +464,12 @@ class DAFNISession:
                         returned (e.g. /models/).
             dict: For an endpoint returning one object, this will be a
                   dictionary (e.g. /models/<version_id>).
+            error_message_func (Optional[Callable[[requests.Response], Optional[str]]]):
+                                Function called on a response after an error to
+                                obtain an error message. If it returns None, a
+                                HTTPError will be returned, otherwise it will be
+                                a DAFNIError. By default this will be
+                                get_error_message.
 
         Raises:
             EndpointNotFoundError: If the response returns a 404 status code
@@ -462,7 +485,7 @@ class DAFNISession:
             json=None,
             allow_redirect=allow_redirect,
         )
-        self._check_response(url, response)
+        self._check_response(url, response, error_message_func=error_message_func)
 
         if content:
             return response.content
@@ -476,6 +499,9 @@ class DAFNISession:
         json=None,
         allow_redirect: bool = False,
         content: bool = False,
+        error_message_func: Optional[
+            Callable[[requests.Response], Optional[str]]
+        ] = None,
     ):
         """Performs a POST request to the DAFNI API
 
@@ -488,6 +514,12 @@ class DAFNISession:
                                    Defaults to False.
             content (bool): Flag to define if the response content is
                             returned. default is the response json
+            error_message_func (Optional[Callable[[requests.Response], Optional[str]]]):
+                                Function called on a response after an error to
+                                obtain an error message. If it returns None, a
+                                HTTPError will be returned, otherwise it will be
+                                a DAFNIError. By default this will be
+                                get_error_message.
 
         Returns:
             List[dict]: For an endpoint returning several objects, a list is
@@ -510,7 +542,7 @@ class DAFNISession:
             allow_redirect=allow_redirect,
         )
 
-        self._check_response(url, response)
+        self._check_response(url, response, error_message_func=error_message_func)
 
         if content:
             return response.content
@@ -524,6 +556,9 @@ class DAFNISession:
         json=None,
         allow_redirect: bool = False,
         content: bool = False,
+        error_message_func: Optional[
+            Callable[[requests.Response], Optional[str]]
+        ] = None,
     ):
         """Performs a PUT request to the DAFNI API
 
@@ -536,6 +571,12 @@ class DAFNISession:
                                    Defaults to False.
             content (bool): Flag to define if the response content is
                             returned. default is the response json
+            error_message_func (Optional[Callable[[requests.Response], Optional[str]]]):
+                                Function called on a response after an error to
+                                obtain an error message. If it returns None, a
+                                HTTPError will be returned, otherwise it will be
+                                a DAFNIError. By default this will be
+                                get_error_message.
 
         Returns:
             List[dict]: For an endpoint returning several objects, a list is
@@ -558,7 +599,7 @@ class DAFNISession:
             allow_redirect=allow_redirect,
         )
 
-        self._check_response(url, response)
+        self._check_response(url, response, error_message_func=error_message_func)
 
         if content:
             return response.content
@@ -572,6 +613,9 @@ class DAFNISession:
         json=None,
         allow_redirect: bool = False,
         content: bool = False,
+        error_message_func: Optional[
+            Callable[[requests.Response], Optional[str]]
+        ] = None,
     ):
         """Performs a PATCH request to the DAFNI API
 
@@ -584,6 +628,12 @@ class DAFNISession:
                                    Defaults to False.
             content (bool): Flag to define if the response content is
                             returned. default is the response json
+            error_message_func (Optional[Callable[[requests.Response], Optional[str]]]):
+                                Function called on a response after an error to
+                                obtain an error message. If it returns None, a
+                                HTTPError will be returned, otherwise it will be
+                                a DAFNIError. By default this will be
+                                get_error_message.
 
         Returns:
             List[dict]: For an endpoint returning several objects, a list is
@@ -606,14 +656,20 @@ class DAFNISession:
             allow_redirect=allow_redirect,
         )
 
-        self._check_response(url, response)
+        self._check_response(url, response, error_message_func=error_message_func)
 
         if content:
             return response.content
         return response.json()
 
     def delete_request(
-        self, url: str, allow_redirect: bool = False, content: bool = False
+        self,
+        url: str,
+        allow_redirect: bool = False,
+        content: bool = False,
+        error_message_func: Optional[
+            Callable[[requests.Response], Optional[str]]
+        ] = None,
     ):
         """Performs a DELETE request to the DAFNI API
 
@@ -623,6 +679,12 @@ class DAFNISession:
                                    Defaults to False.
             content (bool): Flag to define if the response content is
                             returned. default is the response json
+            error_message_func (Optional[Callable[[requests.Response], Optional[str]]]):
+                                Function called on a response after an error to
+                                obtain an error message. If it returns None, a
+                                HTTPError will be returned, otherwise it will be
+                                a DAFNIError. By default this will be
+                                get_error_message.
 
         Returns:
             List[dict]: For an endpoint returning several objects, a list is
@@ -645,7 +707,7 @@ class DAFNISession:
             allow_redirect=allow_redirect,
         )
 
-        self._check_response(url, response)
+        self._check_response(url, response, error_message_func=error_message_func)
 
         if content:
             return response.content

--- a/dafni_cli/api/session.py
+++ b/dafni_cli/api/session.py
@@ -376,14 +376,6 @@ class DAFNISession:
                 error_message = "The following errors were returned:"
                 for error in decoded_response["errors"]:
                     error_message += f"\nError: {error}"
-            # Special case when uploading dataset metadata that's invalid
-            # TODO: This is a bug, remove once fixed
-            elif "metadata" in decoded_response:
-                # This returns a list of errors, add them all to the
-                # message
-                error_message = "Found errors in metadata:"
-                for error in decoded_response["metadata"]:
-                    error_message += f"\n{error}"
 
             return error_message
         except requests.JSONDecodeError:

--- a/dafni_cli/api/session.py
+++ b/dafni_cli/api/session.py
@@ -341,7 +341,7 @@ class DAFNISession:
             else:
                 self._refresh_tokens()
 
-                # It seems in the event the refresh token fail's requests still
+                # It seems in the event the token needs a refresh requests still
                 # reads at least a small part of any file being uploaded - this
                 # for example can result in  the validation of some metadata
                 # files to fail citing that they are missing all parameters when

--- a/dafni_cli/api/workflows_api.py
+++ b/dafni_cli/api/workflows_api.py
@@ -167,7 +167,7 @@ def validate_parameter_set_definition(
     Args:
         session (DAFNISession): User session
         parameter_set_definition_path (Path): Path to the parameter set
-                                              definition files
+                                              definition file
 
     Raises:
         EndpointNotFoundError: If the response returns a 404 status code
@@ -179,6 +179,31 @@ def validate_parameter_set_definition(
     url = f"{NIMS_API_URL}/workflows/parameter-set/validate/"
     with open(parameter_set_definition_path, "rb") as file:
         session.post_request(
+            url=url,
+            data=file,
+            error_message_func=_validate_parameter_set_definition_error_message_func(
+                session
+            ),
+        )
+
+
+def upload_parameter_set(
+    session: DAFNISession, parameter_set_definition_path: Path
+) -> dict:
+    """Uploads a parameter set
+
+    Args:
+        session (DAFNISession): User session
+        parameter_set_definition_path (Path): Path to the parameter set
+                                              definition file
+
+    Returns:
+        dict: JSON from response returned in post request (Forms a
+              WorkflowParameterSet)
+    """
+    url = f"{NIMS_API_URL}/workflows/parameter-set/upload/"
+    with open(parameter_set_definition_path, "rb") as file:
+        return session.post_request(
             url=url,
             data=file,
             error_message_func=_validate_parameter_set_definition_error_message_func(

--- a/dafni_cli/api/workflows_api.py
+++ b/dafni_cli/api/workflows_api.py
@@ -120,3 +120,24 @@ def delete_workflow_version(session: DAFNISession, version_id: str) -> Response:
     """
     url = f"{NIMS_API_URL}/workflows/{version_id}/"
     return session.delete_request(url)
+
+
+def validate_parameter_set_definition(
+    session: DAFNISession, parameter_set_definition_path: Path
+):
+    """Validates a parameter set definition file
+
+    Args:
+        session (DAFNISession): User session
+        parameter_set_definition_path (Path): Path to the parameter set
+                                              definition file
+
+    Raises:
+        ValidationError: If the validation fails
+    """
+    url = f"{NIMS_API_URL}/workflows/parameter-set/validate/"
+    with open(parameter_set_definition_path, "rb") as file:
+        # Error handling should automatically be handled here since
+        # a 200 is returned if validation succeeds and errors are returned
+        # otherwise
+        response = session.post_request(url=url, data=file)

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -8,6 +8,7 @@ from click import Context
 
 from dafni_cli.api.session import DAFNISession
 from dafni_cli.api.workflows_api import (
+    upload_parameter_set,
     upload_workflow,
     validate_parameter_set_definition,
 )
@@ -471,3 +472,9 @@ def workflow_parameter_set(
     argument_confirmation(arguments, confirmation_message)
 
     validate_parameter_set_definition(ctx.obj["session"], definition)
+
+    details = upload_parameter_set(ctx.obj["session"], definition)
+
+    # Output details
+    click.echo("\nUpload successful")
+    click.echo(f"Parameter set ID: {details['id']}")

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -7,7 +7,10 @@ import click
 from click import Context
 
 from dafni_cli.api.session import DAFNISession
-from dafni_cli.api.workflows_api import upload_workflow
+from dafni_cli.api.workflows_api import (
+    upload_workflow,
+    validate_parameter_set_definition,
+)
 from dafni_cli.commands.helpers import cli_get_latest_dataset_metadata
 from dafni_cli.commands.options import dataset_metadata_common_options
 from dafni_cli.datasets.dataset_metadata import parse_dataset_metadata
@@ -441,3 +444,30 @@ def workflow(
 
     click.echo("\nUpload successful")
     click.echo(f"Version ID: {details['id']}")
+
+
+###############################################################################
+# COMMAND: Upload a WORKFLOW PARAMETER SET to DAFNI
+###############################################################################
+@upload.command(help="Upload a workflow parameter set to DAFNI")
+@click.argument(
+    "definition", nargs=1, required=True, type=click.Path(exists=True, path_type=Path)
+)
+@click.pass_context
+def workflow_parameter_set(
+    ctx: Context,
+    definition: Path,
+):
+    """Uploads workflow parameter set to DAFNI
+
+    Args:
+        ctx (Context): contains user session for authentication
+        definition (Path): File path to the parameter set definition file
+    """
+    arguments = [
+        ("Parameter set definition file path", definition),
+    ]
+    confirmation_message = "Confirm parameter set upload?"
+    argument_confirmation(arguments, confirmation_message)
+
+    validate_parameter_set_definition(ctx.obj["session"], definition)

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 
 import click
 from click import Context
+from dafni_cli.api.exceptions import ValidationError
 
 from dafni_cli.api.session import DAFNISession
 from dafni_cli.api.workflows_api import (
@@ -471,8 +472,15 @@ def workflow_parameter_set(
     confirmation_message = "Confirm parameter set upload?"
     argument_confirmation(arguments, confirmation_message)
 
-    validate_parameter_set_definition(ctx.obj["session"], definition)
+    click.echo("Validating parameter set definition")
+    try:
+        validate_parameter_set_definition(ctx.obj["session"], definition)
+    except ValidationError as err:
+        click.echo(err)
 
+        raise SystemExit(1) from err
+
+    click.echo("Uploading parameter set")
     details = upload_parameter_set(ctx.obj["session"], definition)
 
     # Output details

--- a/dafni_cli/utils.py
+++ b/dafni_cli/utils.py
@@ -213,3 +213,36 @@ def format_data_format(value: Optional[str]):
     if value is None:
         return OUTPUT_UNKNOWN_FORMAT
     return DATA_FORMATS.get(value, OUTPUT_UNKNOWN_FORMAT)
+
+
+def construct_validation_errors_from_dict(dictionary: dict, prefix="") -> List[str]:
+    """Convert a validation error dictionary into a list of errors
+
+    e.g.
+    {
+        "metadata": {
+            "description": [
+                "This field is required."
+            ]
+        }
+    }
+
+    becomes
+
+    [ "Error: ( metadata -> description ) - This field is required" ]
+    """
+    errors = []
+    for key, value in dictionary.items():
+        new_prefix = key
+        if prefix != "":
+            new_prefix = f"{prefix} -> {key}"
+
+        if isinstance(value, dict):
+            errors.extend(
+                construct_validation_errors_from_dict(value, prefix=new_prefix)
+            )
+        elif isinstance(value, list):
+            errors.append(f"Error: ( {new_prefix} ) - {value[0]}")
+        else:
+            errors.append(f"Error: ( {new_prefix} ) - {value}")
+    return errors

--- a/test/api/test_models_api.py
+++ b/test/api/test_models_api.py
@@ -119,14 +119,6 @@ class TestModelsAPI(TestCase):
             models_api.validate_model_definition(
                 session, model_definition_path=model_definition_path
             )
-        self.assertEqual(
-            str(err.exception),
-            "Model definition validation failed with the following "
-            f"message:\n\n{session.get_error_message(session.put_request.return_value)}\n\n"
-            "See "
-            "https://docs.secure.dafni.rl.ac.uk/docs/how-to/models/how-to-write-a-model-definition-file/ "
-            "for guidance on writing a model definition file",
-        )
 
         # ASSERT
         open_mock.assert_called_once_with(model_definition_path, "rb")
@@ -134,6 +126,14 @@ class TestModelsAPI(TestCase):
             url=f"{NIMS_API_URL}/models/validate/",
             content_type=VALIDATE_MODEL_CT,
             data=open(model_definition_path, "rb"),
+        )
+        self.assertEqual(
+            str(err.exception),
+            "Model definition validation failed with the following "
+            f"message:\n\n{session.get_error_message(session.put_request.return_value)}\n\n"
+            "See "
+            "https://docs.secure.dafni.rl.ac.uk/docs/how-to/models/how-to-write-a-model-definition-file/ "
+            "for guidance on writing a model definition file",
         )
 
     def test_get_model_upload_urls(self):

--- a/test/api/test_session.py
+++ b/test/api/test_session.py
@@ -246,25 +246,40 @@ class TestDAFNISession(TestCase):
 
     def test_get_error_message_with_no_error(self, mock_requests):
         """Tests get_error_message when there is no error message"""
+
+        # SETUP
         session = self.create_mock_session(True)
 
+        # CALL
         error_message = session.get_error_message(create_mock_response(200, {}))
+
+        # ASSERT
         self.assertEqual(error_message, None)
 
     def test_get_error_message_simple(self, mock_requests):
         """Tests get_error_message when there is a simple error message"""
-        session = self.create_mock_session(True)
 
+        # SETUP
+        session = self.create_mock_session(True)
         mock_response = create_mock_error_response()
+
+        # CALL
         error_message = session.get_error_message(mock_response)
+
+        # ASSERT
         self.assertEqual(error_message, f"Error: {mock_response.json()['error']}")
 
     def test_get_error_message(self, mock_requests):
         """Tests get_error_message when there is a specific error message"""
-        session = self.create_mock_session(True)
 
+        # SETUP
+        session = self.create_mock_session(True)
         mock_response = create_mock_error_message_response()
+
+        # CALL
         error_message = session.get_error_message(mock_response)
+
+        # ASSERT
         self.assertEqual(
             error_message,
             f"Error: {mock_response.json()['error']}, {mock_response.json()['error_message']}",
@@ -272,11 +287,16 @@ class TestDAFNISession(TestCase):
 
     def test_get_error_message_with_multiple_errors(self, mock_requests):
         """Tests get_error_message when there are multiple errors"""
-        session = self.create_mock_session(True)
 
+        # SETUP
+        session = self.create_mock_session(True)
         mock_response = create_mock_errors_response()
-        error_message = session.get_error_message(mock_response)
         expected_errors = mock_response.json()["errors"]
+
+        # CALL
+        error_message = session.get_error_message(mock_response)
+
+        # ASSERT
         self.assertEqual(
             error_message,
             "The following errors were returned:\n"
@@ -285,19 +305,27 @@ class TestDAFNISession(TestCase):
 
     def test_get_error_message_handles_decode_error(self, mock_requests):
         """Tests get_error_message when JSON decoding fails"""
-        session = self.create_mock_session(True)
 
+        # SETUP
+        session = self.create_mock_session(True)
         mock_response = create_mock_error_response()
         # Unpatch this to avoid TypeError in except block
         mock_requests.JSONDecodeError = requests.JSONDecodeError
         mock_response.json.side_effect = requests.JSONDecodeError("", "", 0)
+
+        # CALL
         error_message = session.get_error_message(mock_response)
+
+        # ASSERT
         self.assertEqual(error_message, None)
 
     def test_check_response_raises_endpoint_not_found(self, mock_requests):
         """Tests _check_response raises an EndpointNotFoundError when necessary"""
+
+        # SETUP
         session = self.create_mock_session(True)
 
+        # CALL & ASSERT
         with self.assertRaises(EndpointNotFoundError) as err:
             session._check_response("test_url", create_mock_response(404))
         self.assertEqual(str(err.exception), "Could not find test_url")
@@ -305,10 +333,13 @@ class TestDAFNISession(TestCase):
     def test_check_response_raises_dafni_error(self, mock_requests):
         """Tests _check_response raises a DAFNIError when a specific error is
         given in a failed response"""
+
+        # SETUP
         session = self.create_mock_session(True)
         session.get_error_message = MagicMock()
         session.get_error_message.return_value = "Some error message"
 
+        # CALL & ASSERT
         with self.assertRaises(DAFNIError) as err:
             session._check_response("test_url", create_mock_response(400))
         self.assertEqual(str(err.exception), "Some error message")
@@ -316,10 +347,13 @@ class TestDAFNISession(TestCase):
     def test_check_response_raises_http_error(self, mock_requests):
         """Tests _check_response raises a HTTPError when no specific error
         message is found"""
+
+        # SETUP
         session = self.create_mock_session(True)
         session.get_error_message = MagicMock()
         session.get_error_message.return_value = None
 
+        # CALL & ASSERT
         with self.assertRaises(HTTPError) as err:
             session._check_response("test_url", create_mock_response(400))
         self.assertEqual(str(err.exception), "Test error 400")
@@ -327,10 +361,13 @@ class TestDAFNISession(TestCase):
     def test_check_response_calls_error_message_func(self, mock_requests):
         """Tests _check_response calls the given error message function and uses
         its returned value for the error message when given"""
+
+        # SETUP
         session = self.create_mock_session(True)
         mock_response = create_mock_response(400)
         error_message_func = MagicMock()
 
+        # CALL & ASSERT
         with self.assertRaises(DAFNIError) as err:
             session._check_response(
                 "test_url", mock_response, error_message_func=error_message_func
@@ -342,8 +379,10 @@ class TestDAFNISession(TestCase):
         """Tests sending a request via the DAFNISession uses header based
         authentication"""
 
+        # SETUP
         session = self.create_mock_session(True)
 
+        # CALL
         session._authenticated_request(
             "get",
             url="test_url",
@@ -353,6 +392,7 @@ class TestDAFNISession(TestCase):
             allow_redirect=False,
         )
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "get",
             url="test_url",

--- a/test/api/test_session.py
+++ b/test/api/test_session.py
@@ -3,11 +3,11 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, call, mock_open, patch
 
-from requests import HTTPError
 import requests
+from requests import HTTPError
 
 from dafni_cli.api.exceptions import DAFNIError, EndpointNotFoundError
-from dafni_cli.api.session import DAFNISession, LoginError, SessionData
+from dafni_cli.api.session import DAFNISession, LoginError
 from dafni_cli.consts import (
     LOGIN_API_ENDPOINT,
     LOGOUT_API_ENDPOINT,
@@ -16,15 +16,23 @@ from dafni_cli.consts import (
     URLS_REQUIRING_COOKIE_AUTHENTICATION,
 )
 
-from test.fixtures.session import create_mock_response
-
-TEST_ACCESS_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJsb2dpbi1hcHAtand0IiwiZXhwIjoxNjE0Nzg2MTk0LCJzdWIiOiJlMTA5MmMzZS1iZTA0LTRjMTktOTU3Zi1jZDg4NGU1MzQ0N2UifQ.EZ7dIoMR9e-M1Zm2YavswHrfOMKpq1EJmw_B_m78FkA"
-TEST_SESSION_DATA = SessionData(
-    username="test_username",
-    access_token=TEST_ACCESS_TOKEN,
-    refresh_token="some_refresh_token",
+from test.fixtures.session import (
+    TEST_ACCESS_TOKEN,
+    TEST_SESSION_DATA,
+    TEST_SESSION_FILE,
+    create_mock_access_token_response,
+    create_mock_error_message_response,
+    create_mock_error_response,
+    create_mock_errors_response,
+    create_mock_invalid_login_response,
+    create_mock_invalid_password_response,
+    create_mock_metadata_errors_response,
+    create_mock_refresh_token_expiry_response,
+    create_mock_response,
+    create_mock_success_response,
+    create_mock_token_expiry_redirect_response,
+    create_mock_token_expiry_response,
 )
-TEST_SESSION_FILE = f"{json.dumps(TEST_SESSION_DATA.__dict__)}"
 
 
 @patch("dafni_cli.api.session.requests")
@@ -50,106 +58,6 @@ class TestDAFNISession(TestCase):
                 else:
                     return DAFNISession(), mock_file()
 
-    def create_mock_access_token_response(self):
-        """Creates and returns a MagicMock for replacing requests post response
-        for obtaining an access_token"""
-
-        return create_mock_response(
-            200,
-            {
-                "access_token": TEST_ACCESS_TOKEN,
-                "refresh_token": "some_refresh_token",
-            },
-        )
-
-    def create_mock_token_expiry_response(self):
-        """Returns a mock response indicating an access token as become invalid"""
-        return create_mock_response(
-            403,
-            {
-                "error": "invalid_grant",
-                "error_message": "Some error message",
-            },
-        )
-
-    def create_mock_invalid_login_response(self):
-        """Returns a mock response indicating a username/password was rejected"""
-        return create_mock_response(
-            401,
-            {
-                "error": "invalid_grant",
-                "error_message": "Some error message",
-            },
-        )
-
-    def create_mock_token_expiry_redirect_response(self):
-        """Returns a mock redirect response indicating an access token as become
-        invalid"""
-        return create_mock_response(302)
-
-    def create_mock_refresh_token_expiry_response(self):
-        """Returns a mock response indicating a refresh token has become invalid"""
-        return create_mock_response(
-            400,
-            {
-                "error": "invalid_grant",
-                "error_message": "Some error message",
-            },
-        )
-
-    def create_mock_invalid_password_response(self):
-        """Returns a mock response when logging in with an invalid username or
-        password"""
-        return create_mock_response(
-            401,
-            {
-                "error": "invalid_grant",
-                "error_message": "Some error message",
-            },
-        )
-
-    def create_mock_success_response(self):
-        """Returns a mock successful response"""
-        return create_mock_response(200)
-
-    def create_mock_error_response(self):
-        """Returns a mock response with a single error"""
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.json.return_value = {"error": "Error"}
-        return create_mock_response(
-            400,
-            {"error": "Error"},
-        )
-
-    def create_mock_error_message_response(self):
-        """Returns a mock response with a single error with a message"""
-        return create_mock_response(
-            400,
-            {
-                "error": "Error",
-                "error_message": "Error message",
-            },
-        )
-
-    def create_mock_errors_response(self):
-        """Returns a mock response with a multiple error messages"""
-        return create_mock_response(
-            400,
-            {
-                "errors": ["Sample error 1", "Sample error 2"],
-            },
-        )
-
-    def create_mock_metadata_errors_response(self):
-        """Returns a mock response with a multiple error messages"""
-        return create_mock_response(
-            400,
-            {
-                "metadata": ["Error: Sample error 1", "Error: Sample error 2"],
-            },
-        )
-
     def test_has_session_file(self, mock_requests):
         """Tests has_session_file works correctly"""
 
@@ -169,7 +77,7 @@ class TestDAFNISession(TestCase):
         """Tests loading of session with a given username and password"""
 
         # Setup
-        mock_requests.post.return_value = self.create_mock_access_token_response()
+        mock_requests.post.return_value = create_mock_access_token_response()
 
         # Attempt login
         session = DAFNISession.login(username="test_username", password="test_password")
@@ -197,7 +105,7 @@ class TestDAFNISession(TestCase):
         """Tests loading of session with an invalid username and/or password"""
 
         # Setup
-        mock_requests.post.return_value = self.create_mock_invalid_login_response()
+        mock_requests.post.return_value = create_mock_invalid_login_response()
 
         # Attempt login
         with self.assertRaises(LoginError) as err:
@@ -224,7 +132,7 @@ class TestDAFNISession(TestCase):
 
         # Setup
         mock_click_prompt.side_effect = ["test_username", "test_password"]
-        mock_requests.post.return_value = self.create_mock_access_token_response()
+        mock_requests.post.return_value = create_mock_access_token_response()
 
         # Create session using input from user
         session, mock_file = self.create_mock_session(False, return_mock_file=True)
@@ -267,8 +175,8 @@ class TestDAFNISession(TestCase):
             "test_password",
         ]
         mock_requests.post.side_effect = [
-            self.create_mock_invalid_password_response(),
-            self.create_mock_access_token_response(),
+            create_mock_invalid_password_response(),
+            create_mock_access_token_response(),
         ]
 
         # Create session using input from user
@@ -347,7 +255,7 @@ class TestDAFNISession(TestCase):
         """Tests get_error_message when there is a simple error message"""
         session = self.create_mock_session(True)
 
-        mock_response = self.create_mock_error_response()
+        mock_response = create_mock_error_response()
         error_message = session.get_error_message(mock_response)
         self.assertEqual(error_message, f"Error: {mock_response.json()['error']}")
 
@@ -355,7 +263,7 @@ class TestDAFNISession(TestCase):
         """Tests get_error_message when there is a specific error message"""
         session = self.create_mock_session(True)
 
-        mock_response = self.create_mock_error_message_response()
+        mock_response = create_mock_error_message_response()
         error_message = session.get_error_message(mock_response)
         self.assertEqual(
             error_message,
@@ -366,7 +274,7 @@ class TestDAFNISession(TestCase):
         """Tests get_error_message when there are multiple errors"""
         session = self.create_mock_session(True)
 
-        mock_response = self.create_mock_errors_response()
+        mock_response = create_mock_errors_response()
         error_message = session.get_error_message(mock_response)
         expected_errors = mock_response.json()["errors"]
         self.assertEqual(
@@ -375,24 +283,11 @@ class TestDAFNISession(TestCase):
             f"Error: {expected_errors[0]}\nError: {expected_errors[1]}",
         )
 
-    def test_get_error_message_with_multiple_metadata_errors(self, mock_requests):
-        """Tests get_error_message when there are multiple errors listed under
-        'metadata'"""
-        session = self.create_mock_session(True)
-
-        mock_response = self.create_mock_metadata_errors_response()
-        error_message = session.get_error_message(mock_response)
-        expected_errors = mock_response.json()["metadata"]
-        self.assertEqual(
-            error_message,
-            "Found errors in metadata:\n" f"{expected_errors[0]}\n{expected_errors[1]}",
-        )
-
     def test_get_error_message_handles_decode_error(self, mock_requests):
         """Tests get_error_message when JSON decoding fails"""
         session = self.create_mock_session(True)
 
-        mock_response = self.create_mock_error_response()
+        mock_response = create_mock_error_response()
         # Unpatch this to avoid TypeError in except block
         mock_requests.JSONDecodeError = requests.JSONDecodeError
         mock_response.json.side_effect = requests.JSONDecodeError("", "", 0)
@@ -844,12 +739,12 @@ class TestDAFNISession(TestCase):
         # To trigger a refresh need a response with a 403 status code, then
         # should be successful when retried
         mock_requests.request.side_effect = [
-            self.create_mock_token_expiry_response(),
-            self.create_mock_success_response(),
+            create_mock_token_expiry_response(),
+            create_mock_success_response(),
         ]
 
         # New token
-        mock_requests.post.return_value = self.create_mock_access_token_response()
+        mock_requests.post.return_value = create_mock_access_token_response()
 
         with patch(
             "builtins.open", new_callable=mock_open, read_data=TEST_SESSION_FILE
@@ -890,12 +785,12 @@ class TestDAFNISession(TestCase):
         # To trigger a refresh need a response with a 403 status code, then
         # should be successful when retried
         mock_requests.request.side_effect = [
-            self.create_mock_token_expiry_redirect_response(),
-            self.create_mock_success_response(),
+            create_mock_token_expiry_redirect_response(),
+            create_mock_success_response(),
         ]
 
         # New token
-        mock_requests.post.return_value = self.create_mock_access_token_response()
+        mock_requests.post.return_value = create_mock_access_token_response()
 
         with patch(
             "builtins.open", new_callable=mock_open, read_data=TEST_SESSION_FILE
@@ -934,10 +829,10 @@ class TestDAFNISession(TestCase):
 
         # To trigger a refresh need a response with a 403 status code, then
         # should be successful when retried - here we keep it failing
-        mock_requests.request.return_value = self.create_mock_token_expiry_response()
+        mock_requests.request.return_value = create_mock_token_expiry_response()
 
         # No new token
-        mock_requests.post.return_value = self.create_mock_invalid_login_response()()
+        mock_requests.post.return_value = create_mock_invalid_login_response()()
 
         with self.assertRaises(LoginError) as error:
             # Avoid creating any local files
@@ -958,10 +853,10 @@ class TestDAFNISession(TestCase):
 
         # To trigger a refresh need a response with a 403 status code, then
         # should be successful when retried - here we keep it failing
-        mock_requests.request.return_value = self.create_mock_token_expiry_response()
+        mock_requests.request.return_value = create_mock_token_expiry_response()
 
         # New token
-        mock_requests.post.return_value = self.create_mock_access_token_response()
+        mock_requests.post.return_value = create_mock_access_token_response()
 
         with self.assertRaises(RuntimeError) as error:
             # Avoid creating any local files
@@ -988,15 +883,15 @@ class TestDAFNISession(TestCase):
         # To trigger a refresh need a response with a 403 status code, then
         # should be successful when retried
         mock_requests.request.side_effect = [
-            self.create_mock_token_expiry_response(),
-            self.create_mock_success_response(),
+            create_mock_token_expiry_response(),
+            create_mock_success_response(),
         ]
 
         mock_requests.post.side_effect = [
             # Token authentication expiry when trying to obtain a new one
-            self.create_mock_refresh_token_expiry_response(),
+            create_mock_refresh_token_expiry_response(),
             # Successful login using user provided credentials
-            self.create_mock_access_token_response(),
+            create_mock_access_token_response(),
         ]
 
         # Will want a new username and password

--- a/test/api/test_session.py
+++ b/test/api/test_session.py
@@ -429,6 +429,20 @@ class TestDAFNISession(TestCase):
             session._check_response("test_url", create_mock_response(400))
         self.assertEqual(str(err.exception), "Test error 400")
 
+    def test_check_response_calls_error_message_func(self, mock_requests):
+        """Tests _check_response calls the given error message function and uses
+        its returned value for the error message when given"""
+        session = self.create_mock_session(True)
+        mock_response = create_mock_response(400)
+        error_message_func = MagicMock()
+
+        with self.assertRaises(DAFNIError) as err:
+            session._check_response(
+                "test_url", mock_response, error_message_func=error_message_func
+            )
+        error_message_func.assert_called_once_with(mock_response)
+        self.assertEqual(str(err.exception), f"{error_message_func.return_value}")
+
     def test_authenticated_request_header_auth(self, mock_requests):
         """Tests sending a request via the DAFNISession uses header based
         authentication"""
@@ -492,11 +506,14 @@ class TestDAFNISession(TestCase):
     def test_get_request(self, mock_requests):
         """Tests sending a get request via the DAFNISession"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
 
+        # CALL
         result = session.get_request(url="some_test_url", content_type="content_type")
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "get",
             url="some_test_url",
@@ -510,20 +527,30 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url", mock_requests.request.return_value, error_message_func=None
         )
         self.assertEqual(result, mock_requests.request.return_value.json.return_value)
 
-    def test_get_request_when_content_true(self, mock_requests):
-        """Tests sending a get request via the DAFNISession when content=True"""
+    def test_get_request_when_content_true_and_given_error_message_func(
+        self, mock_requests
+    ):
+        """Tests sending a get request via the DAFNISession when content=True
+        and given an error message function"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
+        error_message_func = MagicMock()
 
+        # CALL
         result = session.get_request(
-            url="some_test_url", content_type="content_type", content=True
+            url="some_test_url",
+            content_type="content_type",
+            content=True,
+            error_message_func=error_message_func,
         )
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "get",
             url="some_test_url",
@@ -537,18 +564,23 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url",
+            mock_requests.request.return_value,
+            error_message_func=error_message_func,
         )
         self.assertEqual(result, mock_requests.request.return_value.content)
 
     def test_post_request(self, mock_requests):
         """Tests sending a post request via the DAFNISession"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
 
+        # CALL
         result = session.post_request(url="some_test_url", content_type="content_type")
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "post",
             url="some_test_url",
@@ -562,20 +594,30 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url", mock_requests.request.return_value, error_message_func=None
         )
         self.assertEqual(result, mock_requests.request.return_value.json.return_value)
 
-    def test_post_request_when_content_true(self, mock_requests):
-        """Tests sending a post request via the DAFNISession when content=True"""
+    def test_post_request_when_content_true_and_given_error_message_func(
+        self, mock_requests
+    ):
+        """Tests sending a post request via the DAFNISession when content=True
+        and given an error message function"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
+        error_message_func = MagicMock()
 
+        # CALL
         result = session.post_request(
-            url="some_test_url", content_type="content_type", content=True
+            url="some_test_url",
+            content_type="content_type",
+            content=True,
+            error_message_func=error_message_func,
         )
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "post",
             url="some_test_url",
@@ -589,18 +631,23 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url",
+            mock_requests.request.return_value,
+            error_message_func=error_message_func,
         )
         self.assertEqual(result, mock_requests.request.return_value.content)
 
     def test_put_request(self, mock_requests):
         """Tests sending a put request via the DAFNISession"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
 
+        # CALL
         result = session.put_request(url="some_test_url", content_type="content_type")
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "put",
             url="some_test_url",
@@ -614,20 +661,30 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url", mock_requests.request.return_value, error_message_func=None
         )
         self.assertEqual(result, mock_requests.request.return_value)
 
-    def test_put_request_when_content_true(self, mock_requests):
-        """Tests sending a put request via the DAFNISession when content=True"""
+    def test_put_request_when_content_true_and_given_error_message_func(
+        self, mock_requests
+    ):
+        """Tests sending a put request via the DAFNISession when content=True
+        and given an error message function"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
+        error_message_func = MagicMock()
 
+        # CALL
         result = session.put_request(
-            url="some_test_url", content_type="content_type", content=True
+            url="some_test_url",
+            content_type="content_type",
+            content=True,
+            error_message_func=error_message_func,
         )
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "put",
             url="some_test_url",
@@ -641,18 +698,23 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url",
+            mock_requests.request.return_value,
+            error_message_func=error_message_func,
         )
         self.assertEqual(result, mock_requests.request.return_value.content)
 
     def test_patch_request(self, mock_requests):
         """Tests sending a patch request via the DAFNISession"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
 
+        # CALL
         result = session.patch_request(url="some_test_url", content_type="content_type")
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "patch",
             url="some_test_url",
@@ -666,20 +728,30 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url", mock_requests.request.return_value, error_message_func=None
         )
         self.assertEqual(result, mock_requests.request.return_value.json.return_value)
 
-    def test_patch_request_when_content_true(self, mock_requests):
-        """Tests sending a patch request via the DAFNISession when content=True"""
+    def test_patch_request_when_content_true_and_given_error_message_func(
+        self, mock_requests
+    ):
+        """Tests sending a patch request via the DAFNISession when content=True
+        and given an error message function"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
+        error_message_func = MagicMock()
 
+        # CALL
         result = session.patch_request(
-            url="some_test_url", content_type="content_type", content=True
+            url="some_test_url",
+            content_type="content_type",
+            content=True,
+            error_message_func=error_message_func,
         )
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "patch",
             url="some_test_url",
@@ -693,18 +765,23 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url",
+            mock_requests.request.return_value,
+            error_message_func=error_message_func,
         )
         self.assertEqual(result, mock_requests.request.return_value.content)
 
     def test_delete_request(self, mock_requests):
         """Tests sending a delete request via the DAFNISession"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
 
+        # CALL
         result = session.delete_request(url="some_test_url")
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "delete",
             url="some_test_url",
@@ -717,18 +794,27 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url", mock_requests.request.return_value, error_message_func=None
         )
         self.assertEqual(result, mock_requests.request.return_value)
 
-    def test_delete_request_when_content_true(self, mock_requests):
-        """Tests sending a delete request via the DAFNISession when content=True"""
+    def test_delete_request_when_content_true_and_given_error_message_func(
+        self, mock_requests
+    ):
+        """Tests sending a delete request via the DAFNISession when content=True
+        and given an error message function"""
 
+        # SETUP
         session = self.create_mock_session(True)
         session._check_response = MagicMock()
+        error_message_func = MagicMock()
 
-        result = session.delete_request(url="some_test_url", content=True)
+        # CALL
+        result = session.delete_request(
+            url="some_test_url", content=True, error_message_func=error_message_func
+        )
 
+        # ASSERT
         mock_requests.request.assert_called_once_with(
             "delete",
             url="some_test_url",
@@ -741,7 +827,9 @@ class TestDAFNISession(TestCase):
             timeout=REQUESTS_TIMEOUT,
         )
         session._check_response.assert_called_once_with(
-            "some_test_url", mock_requests.request.return_value
+            "some_test_url",
+            mock_requests.request.return_value,
+            error_message_func=error_message_func,
         )
         self.assertEqual(result, mock_requests.request.return_value.content)
 

--- a/test/api/test_workflows_api.py
+++ b/test/api/test_workflows_api.py
@@ -297,3 +297,28 @@ class TestWorkflowsAPI(TestCase):
             data=open(parameter_set_definition_path, "rb"),
             error_message_func=mock_error_message_func.return_value,
         )
+
+    @patch("builtins.open", new_callable=mock_open, read_data="definition file")
+    @patch(
+        "dafni_cli.api.workflows_api._validate_parameter_set_definition_error_message_func"
+    )
+    def test_upload_parameter_set(self, mock_error_message_func, open_mock):
+        """Tests that upload_parameter_set works as expected"""
+
+        # SETUP
+        session = MagicMock()
+        parameter_set_definition_path = Path("path/to/file")
+        session.put_request.return_value = create_mock_response(200)
+
+        # CALL
+        workflows_api.upload_parameter_set(
+            session, parameter_set_definition_path=parameter_set_definition_path
+        )
+
+        # ASSERT
+        open_mock.assert_called_once_with(parameter_set_definition_path, "rb")
+        session.post_request.assert_called_once_with(
+            url=f"{NIMS_API_URL}/workflows/parameter-set/upload/",
+            data=open(parameter_set_definition_path, "rb"),
+            error_message_func=mock_error_message_func.return_value,
+        )

--- a/test/api/test_workflows_api.py
+++ b/test/api/test_workflows_api.py
@@ -1,10 +1,15 @@
+import json
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, mock_open, patch
 
+import requests
+
 from dafni_cli.api import workflows_api
 from dafni_cli.api.exceptions import EndpointNotFoundError, ResourceNotFoundError
 from dafni_cli.consts import NIMS_API_URL
+
+from test.fixtures.session import create_mock_error_response, create_mock_response
 
 
 class TestWorkflowsAPI(TestCase):
@@ -190,3 +195,105 @@ class TestWorkflowsAPI(TestCase):
             f"{NIMS_API_URL}/workflows/{version_id}/",
         )
         self.assertEqual(result, session.delete_request.return_value)
+
+    def test_validate_parameter_set_definition_error_message_func_when_error_found(
+        self,
+    ):
+        """Tests that _validate_parameter_set_definition_error_message_func
+        functions as expected when the session object returns an error message"""
+
+        # SETUP
+        session = MagicMock()
+        session.get_error_message = MagicMock()
+        error_message_func = (
+            workflows_api._validate_parameter_set_definition_error_message_func(session)
+        )
+        mock_response = create_mock_error_response()
+
+        # CALL
+        error_message = error_message_func(mock_response)
+
+        # ASSERT
+        self.assertEqual(error_message, session.get_error_message.return_value)
+
+    def test_validate_parameter_set_definition_error_message_func_validation_error(
+        self,
+    ):
+        """Tests that _validate_parameter_set_definition_error_message_func
+        functions as expected when validation errors are returned under a
+        dictionary similar to the definition that would have been uploaded
+        """
+
+        # SETUP
+        session = MagicMock()
+        session.get_error_message = MagicMock(return_value=None)
+        error_message_func = (
+            workflows_api._validate_parameter_set_definition_error_message_func(session)
+        )
+        mock_response = create_mock_response(
+            400,
+            {
+                "api_version": ["This field is required."],
+                "kind": ["This field is required."],
+                "metadata": ["This field is required."],
+            },
+        )
+
+        # CALL
+        error_message = error_message_func(mock_response)
+
+        # ASSERT
+        self.assertEqual(
+            error_message,
+            "Found the following errors in the definition:\n"
+            + json.dumps(mock_response.json(), indent=2, sort_keys=True),
+        )
+
+    def test_validate_parameter_set_definition_error_message_func_handles_decode_error(
+        self,
+    ):
+        """Tests _validate_parameter_set_definition_error_message_func when
+        JSON decoding fails"""
+
+        # SETUP
+        session = MagicMock()
+        session.get_error_message = MagicMock(return_value=None)
+        error_message_func = (
+            workflows_api._validate_parameter_set_definition_error_message_func(session)
+        )
+        mock_response = create_mock_error_response()
+        mock_response.json.side_effect = requests.JSONDecodeError("", "", 0)
+
+        # CALL
+        error_message = error_message_func(mock_response)
+
+        # ASSERT
+        self.assertEqual(error_message, None)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="definition file")
+    @patch(
+        "dafni_cli.api.workflows_api._validate_parameter_set_definition_error_message_func"
+    )
+    def test_validate_parameter_set_definition(
+        self, mock_error_message_func, open_mock
+    ):
+        """Tests that test_validate_parameter_set_definition works as expected
+        when the definition is found to be valid"""
+
+        # SETUP
+        session = MagicMock()
+        parameter_set_definition_path = Path("path/to/file")
+        session.put_request.return_value = create_mock_response(200)
+
+        # CALL
+        workflows_api.validate_parameter_set_definition(
+            session, parameter_set_definition_path=parameter_set_definition_path
+        )
+
+        # ASSERT
+        open_mock.assert_called_once_with(parameter_set_definition_path, "rb")
+        session.post_request.assert_called_once_with(
+            url=f"{NIMS_API_URL}/workflows/parameter-set/validate/",
+            data=open(parameter_set_definition_path, "rb"),
+            error_message_func=mock_error_message_func.return_value,
+        )

--- a/test/api/test_workflows_api.py
+++ b/test/api/test_workflows_api.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, mock_open, patch
@@ -283,7 +282,7 @@ class TestWorkflowsAPI(TestCase):
     def test_validate_parameter_set_definition(
         self, mock_error_message_func, open_mock
     ):
-        """Tests that test_validate_parameter_set_definition works as expected
+        """Tests that validate_parameter_set_definition works as expected
         when the definition is found to be valid"""
 
         # SETUP
@@ -311,7 +310,7 @@ class TestWorkflowsAPI(TestCase):
     def test_validate_parameter_set_definition_when_def_invalid(
         self, mock_error_message_func, open_mock
     ):
-        """Tests that test_validate_parameter_set_definition works as expected
+        """Tests that validate_parameter_set_definition works as expected
         when the definition is found to be invalid"""
 
         # SETUP
@@ -349,7 +348,6 @@ class TestWorkflowsAPI(TestCase):
         # SETUP
         session = MagicMock()
         parameter_set_definition_path = Path("path/to/file")
-        session.put_request.return_value = create_mock_response(200)
 
         # CALL
         workflows_api.upload_parameter_set(

--- a/test/api/test_workflows_api.py
+++ b/test/api/test_workflows_api.py
@@ -13,6 +13,7 @@ from dafni_cli.api.exceptions import (
     ValidationError,
 )
 from dafni_cli.consts import NIMS_API_URL
+from dafni_cli.utils import construct_validation_errors_from_dict
 
 from test.fixtures.session import create_mock_error_response, create_mock_response
 
@@ -251,7 +252,7 @@ class TestWorkflowsAPI(TestCase):
         self.assertEqual(
             error_message,
             "Found the following errors in the definition:\n"
-            + json.dumps(mock_response.json(), indent=2, sort_keys=True),
+            + "\n".join(construct_validation_errors_from_dict(mock_response.json())),
         )
 
     def test_validate_parameter_set_definition_error_message_func_handles_decode_error(

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -1219,3 +1219,98 @@ class TestUploadWorkflow(TestCase):
             "Aborted!\n",
         )
         self.assertEqual(result.exit_code, 1)
+
+
+@patch("dafni_cli.commands.upload.DAFNISession")
+@patch("dafni_cli.commands.upload.validate_parameter_set_definition")
+@patch("dafni_cli.commands.upload.upload_parameter_set")
+class TestUploadWorkflowParameterSet(TestCase):
+    """Test class to test the upload workflow-parameter-set commands"""
+
+    def test_upload_workflow_parameter_set(
+        self,
+        mock_upload_parameter_set,
+        mock_validate_parameter_set_definition,
+        mock_DAFNISession,
+    ):
+        """Tests that the 'upload workflow-parameter-set' command works
+        correctly"""
+
+        # SETUP
+        session = MagicMock()
+        mock_DAFNISession.return_value = session
+        runner = CliRunner()
+        parameter_set_id = "parameter-set-id"
+        mock_upload_parameter_set.return_value = {"id": parameter_set_id}
+
+        # CALL
+        with runner.isolated_filesystem():
+            with open("test_definition.json", "w", encoding="utf-8") as file:
+                file.write("test definition file")
+            result = runner.invoke(
+                upload.upload,
+                [
+                    "workflow-parameter-set",
+                    "test_definition.json",
+                ],
+                input="y",
+            )
+
+        # ASSERT
+        mock_DAFNISession.assert_called_once()
+        mock_validate_parameter_set_definition.assert_called_once_with(
+            session, Path("test_definition.json")
+        )
+        mock_upload_parameter_set.assert_called_once_with(
+            session, Path("test_definition.json")
+        )
+
+        self.assertEqual(
+            result.output,
+            "Parameter set definition file path: test_definition.json\n"
+            "Confirm parameter set upload? [y/N]: y\n"
+            "\nUpload successful\n"
+            f"Parameter set ID: {parameter_set_id}\n",
+        )
+        self.assertEqual(result.exit_code, 0)
+
+    def test_upload_workflow_parameter_set_cancel(
+        self,
+        mock_upload_parameter_set,
+        mock_validate_parameter_set_definition,
+        mock_DAFNISession,
+    ):
+        """Tests that the 'upload workflow-parameter-set' command can be canceled"""
+
+        # SETUP
+        session = MagicMock()
+        mock_DAFNISession.return_value = session
+        runner = CliRunner()
+        parameter_set_id = "parameter-set-id"
+        mock_upload_parameter_set.return_value = {"id": parameter_set_id}
+
+        # CALL
+        with runner.isolated_filesystem():
+            with open("test_definition.json", "w", encoding="utf-8") as file:
+                file.write("test definition file")
+            result = runner.invoke(
+                upload.upload,
+                [
+                    "workflow-parameter-set",
+                    "test_definition.json",
+                ],
+                input="n",
+            )
+
+        # ASSERT
+        mock_DAFNISession.assert_called_once()
+        mock_validate_parameter_set_definition.assert_not_called()
+        mock_upload_parameter_set.assert_not_called()
+
+        self.assertEqual(
+            result.output,
+            "Parameter set definition file path: test_definition.json\n"
+            "Confirm parameter set upload? [y/N]: n\n"
+            "Aborted!\n",
+        )
+        self.assertEqual(result.exit_code, 1)

--- a/test/fixtures/session.py
+++ b/test/fixtures/session.py
@@ -1,7 +1,18 @@
+import json
 from typing import Optional
 from unittest.mock import MagicMock
 
 from requests import HTTPError
+
+from dafni_cli.api.session import SessionData
+
+TEST_ACCESS_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJsb2dpbi1hcHAtand0IiwiZXhwIjoxNjE0Nzg2MTk0LCJzdWIiOiJlMTA5MmMzZS1iZTA0LTRjMTktOTU3Zi1jZDg4NGU1MzQ0N2UifQ.EZ7dIoMR9e-M1Zm2YavswHrfOMKpq1EJmw_B_m78FkA"
+TEST_SESSION_DATA = SessionData(
+    username="test_username",
+    access_token=TEST_ACCESS_TOKEN,
+    refresh_token="some_refresh_token",
+)
+TEST_SESSION_FILE = f"{json.dumps(TEST_SESSION_DATA.__dict__)}"
 
 
 def create_mock_response(status_code: int, json: Optional[dict] = None):
@@ -26,3 +37,114 @@ def create_mock_response(status_code: int, json: Optional[dict] = None):
             f"Test error {status_code}"
         )
     return mock_response
+
+
+def create_mock_access_token_response():
+    """Creates and returns a MagicMock for replacing requests post response
+    for obtaining an access_token"""
+
+    return create_mock_response(
+        200,
+        {
+            "access_token": TEST_ACCESS_TOKEN,
+            "refresh_token": "some_refresh_token",
+        },
+    )
+
+
+def create_mock_token_expiry_response():
+    """Returns a mock response indicating an access token as become invalid"""
+    return create_mock_response(
+        403,
+        {
+            "error": "invalid_grant",
+            "error_message": "Some error message",
+        },
+    )
+
+
+def create_mock_invalid_login_response():
+    """Returns a mock response indicating a username/password was rejected"""
+    return create_mock_response(
+        401,
+        {
+            "error": "invalid_grant",
+            "error_message": "Some error message",
+        },
+    )
+
+
+def create_mock_token_expiry_redirect_response():
+    """Returns a mock redirect response indicating an access token as become
+    invalid"""
+    return create_mock_response(302)
+
+
+def create_mock_refresh_token_expiry_response():
+    """Returns a mock response indicating a refresh token has become invalid"""
+    return create_mock_response(
+        400,
+        {
+            "error": "invalid_grant",
+            "error_message": "Some error message",
+        },
+    )
+
+
+def create_mock_invalid_password_response():
+    """Returns a mock response when logging in with an invalid username or
+    password"""
+    return create_mock_response(
+        401,
+        {
+            "error": "invalid_grant",
+            "error_message": "Some error message",
+        },
+    )
+
+
+def create_mock_success_response():
+    """Returns a mock successful response"""
+    return create_mock_response(200)
+
+
+def create_mock_error_response():
+    """Returns a mock response with a single error"""
+    mock_response = MagicMock()
+    mock_response.status_code = 400
+    mock_response.json.return_value = {"error": "Error"}
+    return create_mock_response(
+        400,
+        {"error": "Error"},
+    )
+
+
+def create_mock_error_message_response():
+    """Returns a mock response with a single error with a message"""
+    return create_mock_response(
+        400,
+        {
+            "error": "Error",
+            "error_message": "Error message",
+        },
+    )
+
+
+def create_mock_errors_response():
+    """Returns a mock response with a multiple error messages"""
+    return create_mock_response(
+        400,
+        {
+            "errors": ["Sample error 1", "Sample error 2"],
+        },
+    )
+
+
+def create_mock_metadata_errors_response():
+    """Returns a mock response with a multiple error messages"""
+    return create_mock_response(
+        400,
+        {
+            "metadata": ["Error: Sample error 1", "Error: Sample error 2"],
+        },
+    )

--- a/test/fixtures/session.py
+++ b/test/fixtures/session.py
@@ -110,9 +110,6 @@ def create_mock_success_response():
 
 def create_mock_error_response():
     """Returns a mock response with a single error"""
-    mock_response = MagicMock()
-    mock_response.status_code = 400
-    mock_response.json.return_value = {"error": "Error"}
     return create_mock_response(
         400,
         {"error": "Error"},

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -518,3 +518,29 @@ class TestFormatDataFormat(TestCase):
     def test_formats_none_correctly(self):
         """Tests that passing None returns the correct value"""
         self.assertEqual(utils.format_data_format(None), OUTPUT_UNKNOWN_FORMAT)
+
+
+class TestConstructValidationErrorsFromDict(TestCase):
+    """Test class to test the construct_validation_errors_from_dict function"""
+
+    def test_formats_correctly(self):
+        """Tests construct_validation_errors_from_dict works correctly"""
+
+        dictionary = {
+            "metadata": {
+                "description": ["This field is required"],
+                "nested": {"error": "test"},
+            },
+            "more_errors": {"hello": "world"},
+        }
+
+        result = utils.construct_validation_errors_from_dict(dictionary)
+
+        self.assertEqual(
+            result,
+            [
+                "Error: ( metadata -> description ) - This field is required",
+                "Error: ( metadata -> nested -> error ) - test",
+                "Error: ( more_errors -> hello ) - world",
+            ],
+        )


### PR DESCRIPTION
Adds an `upload workflow-parameter-set` command.

e.g. 
![image](https://github.com/dafnifacility/cli/assets/90245114/91ad852a-7e9f-4335-a5ee-219b1e774f46)

Other notes
---
- The error handling needed to be different for the upload and validate endpoints - This makes it difficult to detect a specific validation error vs any other error that may come from DAFNI. As a result, I have currently taken the approach to treat all errors with error messages (DAFNIErrors) from the validation endpoint as a validation error, and then print those errors nicely like is done for model upload. Alternatively I could leave the full stack trace in instead, but then it will not be as clear to a user, and I don't know of any error messages we may expect from this endpoint that aren't validation related anyway.
e.g.
![image](https://github.com/dafnifacility/cli/assets/90245114/86d6c57a-466e-4c40-82b2-767eaa110cc2)
(This should match the front ends parsing of error messages for this endpoint)
and 
![image](https://github.com/dafnifacility/cli/assets/90245114/2d88d8c8-8d66-4fc4-b87f-2a2d94c06b5d)
- Fixes a bug where uploading a file, such as when validating metadata, after the token has failed and is due a refresh, causes the validation to fail stating that everything is a missing parameter - it turns out resetting the file back to the start after authentication failure fixes this. I also tested uploading a 700mb file where the token expired mid upload - this change does not effect that as the authentication only happens at the start of the upload, not the middle.
