### PR TITLE
feat: Add default sorting to some tables [CORE-3169]

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Workflows:
 * Filter list of available workflow instances - DONE
 * View specific workflow instance metadata - DONE
 * Create workflow (using workflow definition file) - DONE
+* View a specific workflow parameter set - DONE
+* Upload a new workflow parameter set - DONE
 * Edit workflow env params and create new workflow
 * Edit workflow data slots and create new workflow
 

--- a/dafni_cli/commands/get.py
+++ b/dafni_cli/commands/get.py
@@ -572,7 +572,12 @@ def workflow_instances(
                     TABLE_FINISHED_HEADER,
                     TABLE_STATUS_HEADER,
                 ],
-                rows=[instance.get_brief_details() for instance in filtered_instances],
+                rows=[
+                    instance.get_brief_details()
+                    for instance in sorted(
+                        filtered_instances, key=lambda inst: inst.finished_time
+                    )
+                ],
             )
         )
 

--- a/dafni_cli/models/inputs.py
+++ b/dafni_cli/models/inputs.py
@@ -103,9 +103,14 @@ class ModelInputs(ParserBaseObject):
         """Formats input parameters for a model into a string which prints as
            a table
 
+        If there aren't any parameters will return a string stating that
+
         Returns:
             str: Formatted string that will appear as a table when printed
         """
+        if not self.parameters:
+            return "No parameters"
+
         return format_table(
             headers=[
                 TABLE_TITLE_HEADER,
@@ -128,7 +133,7 @@ class ModelInputs(ParserBaseObject):
                     parameter.default,
                     "Yes" if parameter.required else "No",
                 ]
-                for parameter in self.parameters
+                for parameter in sorted(self.parameters, key=lambda param: param.name)
             ],
             max_column_widths=[
                 None,
@@ -146,36 +151,39 @@ class ModelInputs(ParserBaseObject):
         """Formats input data slots for a model into a string which prints as
            a table
 
+        If there aren't any dataslots will return a string stating that
+
         Returns:
             Optional[str]: str: Formatted string that will appear as a table
                                 when printed
         """
 
-        if self.dataslots:
-            return format_table(
-                headers=[
-                    TABLE_TITLE_HEADER,
-                    TABLE_DESCRIPTION_HEADER,
-                    TABLE_PATH_IN_CONTAINER_HEADER,
-                    TABLE_DEFAULT_DATASETS_HEADER,
-                    TABLE_REQUIRED_HEADER,
-                ],
-                rows=[
-                    [
-                        dataslot.name,
-                        dataslot.description,
-                        dataslot.path,
-                        "\n".join(dataslot.defaults),
-                        "Yes" if dataslot.required else "No",
-                    ]
-                    for dataslot in self.dataslots
-                ],
-                max_column_widths=[
-                    None,
-                    TABLE_DESCRIPTION_MAX_COLUMN_WIDTH,
-                    None,
-                    None,
-                    None,
-                ],
-            )
-        return None
+        if not self.dataslots:
+            return "No dataslots"
+
+        return format_table(
+            headers=[
+                TABLE_TITLE_HEADER,
+                TABLE_DESCRIPTION_HEADER,
+                TABLE_PATH_IN_CONTAINER_HEADER,
+                TABLE_DEFAULT_DATASETS_HEADER,
+                TABLE_REQUIRED_HEADER,
+            ],
+            rows=[
+                [
+                    dataslot.name,
+                    dataslot.description,
+                    dataslot.path,
+                    "\n".join(dataslot.defaults),
+                    "Yes" if dataslot.required else "No",
+                ]
+                for dataslot in sorted(self.dataslots, key=lambda dslot: dslot.name)
+            ],
+            max_column_widths=[
+                None,
+                TABLE_DESCRIPTION_MAX_COLUMN_WIDTH,
+                None,
+                None,
+                None,
+            ],
+        )

--- a/dafni_cli/models/outputs.py
+++ b/dafni_cli/models/outputs.py
@@ -49,9 +49,14 @@ class ModelOutputs(ParserBaseObject):
     def format_outputs(self) -> str:
         """Formats output files into a string which prints as a table
 
+        If there aren't any outputs will return a string stating that
+
         Returns:
             str: Formatted string that will appear as a table when printed
         """
+
+        if not self.datasets:
+            return "No outputs"
 
         # The dataset outputs fields are not mandatory and any or all of them might not
         # exist. Unset fields will be reported as "Unknown" in the formatted output.
@@ -67,7 +72,7 @@ class ModelOutputs(ParserBaseObject):
                     dataset.type or "Unknown",
                     dataset.description,
                 ]
-                for dataset in self.datasets
+                for dataset in sorted(self.datasets, key=lambda dset: dset.name)
             ],
             max_column_widths=[None, None, TABLE_SUMMARY_MAX_COLUMN_WIDTH],
         )

--- a/dafni_cli/workflows/workflow.py
+++ b/dafni_cli/workflows/workflow.py
@@ -201,7 +201,10 @@ class Workflow(ParserBaseObject):
                     parameter_set.metadata.publisher,
                     format_datetime(parameter_set.publication_date, include_time=False),
                 ]
-                for parameter_set in self.parameter_sets
+                for parameter_set in sorted(
+                    self.parameter_sets,
+                    key=lambda param_set: param_set.publication_date,
+                )
             ],
         )
 
@@ -220,7 +223,13 @@ class Workflow(ParserBaseObject):
                 TABLE_FINISHED_HEADER,
                 TABLE_STATUS_HEADER,
             ],
-            rows=[instance.get_brief_details() for instance in self.instances],
+            rows=[
+                instance.get_brief_details()
+                for instance in sorted(
+                    self.instances,
+                    key=lambda inst: inst.finished_time,
+                )
+            ],
         )
 
     def output_details(self):

--- a/test/models/test_inputs.py
+++ b/test/models/test_inputs.py
@@ -140,7 +140,9 @@ class TestInputs(TestCase):
             copy.deepcopy(model_inputs.parameters[0]),
         ]
         model_inputs.parameters[0].required = True
+        model_inputs.parameters[0].name = "YEAR"
         model_inputs.parameters[1].required = False
+        model_inputs.parameters[1].name = "ANOTHER_YEAR"
 
         # CALL
         result = model_inputs.format_parameters()
@@ -158,15 +160,16 @@ class TestInputs(TestCase):
                 TABLE_REQUIRED_HEADER,
             ],
             rows=[
+                # Should be in alphabetical order of names
                 [
                     "Year input",
                     "Year input description",
-                    "YEAR",
+                    "ANOTHER_YEAR",
                     "integer",
                     2016,
                     2025,
                     2018,
-                    "Yes",
+                    "No",
                 ],
                 [
                     "Year input",
@@ -176,7 +179,7 @@ class TestInputs(TestCase):
                     2016,
                     2025,
                     2018,
-                    "No",
+                    "Yes",
                 ],
             ],
             max_column_widths=[
@@ -192,6 +195,20 @@ class TestInputs(TestCase):
         )
         self.assertEqual(result, mock_format_table.return_value)
 
+    def test_format_parameters_if_there_are_no_parameters(self):
+        """Tests format_parameters works correctly when there are no parameters"""
+        # SETUP
+        model_inputs: ModelInputs = ParserBaseObject.parse_from_dict(
+            ModelInputs, TEST_MODEL_INPUTS_DEFAULT
+        )
+        model_inputs.parameters = []
+
+        # CALL
+        result = model_inputs.format_parameters()
+
+        # ASSERT
+        self.assertEqual(result, "No parameters")
+
     @patch("dafni_cli.models.inputs.format_table")
     def test_format_dataslots_if_it_exists(self, mock_format_table):
         """Tests format_dataslots works correctly"""
@@ -206,7 +223,9 @@ class TestInputs(TestCase):
             copy.deepcopy(model_inputs.dataslots[0]),
         ]
         model_inputs.dataslots[0].required = True
+        model_inputs.dataslots[0].name = "Inputs"
         model_inputs.dataslots[1].required = False
+        model_inputs.dataslots[1].name = "Another input"
 
         # CALL
         result = model_inputs.format_dataslots()
@@ -221,19 +240,20 @@ class TestInputs(TestCase):
                 TABLE_REQUIRED_HEADER,
             ],
             rows=[
+                # Should be in alphabetical order of names
                 [
-                    "Inputs",
+                    "Another input",
                     "Dataslot description",
                     "inputs/",
                     "0a0a0a0a-0a00-0a00-a000-0a0a0000000f",
-                    "Yes",
+                    "No",
                 ],
                 [
                     "Inputs",
                     "Dataslot description",
                     "inputs/",
                     "0a0a0a0a-0a00-0a00-a000-0a0a0000000f",
-                    "No",
+                    "Yes",
                 ],
             ],
             max_column_widths=[
@@ -293,7 +313,7 @@ class TestInputs(TestCase):
         )
         self.assertEqual(result, mock_format_table.return_value)
 
-    def test_none_returned_if_there_are_no_dataslots(self):
+    def test_format_dataslots_if_there_are_no_dataslots(self):
         """Tests format_dataslots works correctly when there are no dataslots"""
         # SETUP
         model_inputs: ModelInputs = ParserBaseObject.parse_from_dict(
@@ -301,7 +321,7 @@ class TestInputs(TestCase):
         )
 
         # CALL
-        dataslot_string = model_inputs.format_dataslots()
+        result = model_inputs.format_dataslots()
 
         # ASSERT
-        self.assertEqual(dataslot_string, None)
+        self.assertEqual(result, "No dataslots")

--- a/test/models/test_outputs.py
+++ b/test/models/test_outputs.py
@@ -1,3 +1,4 @@
+import copy
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -59,7 +60,10 @@ class TestModelOutputs(TestCase):
             ModelOutputs, TEST_MODEL_OUTPUTS
         )
         # Repeat the first one twice
-        model_outputs.datasets.append(model_outputs.datasets[0])
+        model_outputs.datasets.append(copy.deepcopy(model_outputs.datasets[0]))
+
+        model_outputs.datasets[0].name = "example_dataset.csv"
+        model_outputs.datasets[1].name = "another_dataset.csv"
 
         # CALL
         result = model_outputs.format_outputs()
@@ -72,7 +76,8 @@ class TestModelOutputs(TestCase):
                 TABLE_SUMMARY_HEADER,
             ],
             rows=[
-                ["example_dataset.csv", "CSV", ""],
+                # Should be in alphabetical order of names
+                ["another_dataset.csv", "CSV", ""],
                 ["example_dataset.csv", "CSV", ""],
             ],
             max_column_widths=[
@@ -117,3 +122,17 @@ class TestModelOutputs(TestCase):
             ],
         )
         self.assertEqual(result, mock_format_table.return_value)
+
+    def test_format_outputs_if_there_are_no_outputs(self):
+        """Tests format_outputs works correctly when there are no parameters"""
+        # SETUP
+        model_outputs: ModelOutputs = ParserBaseObject.parse_from_dict(
+            ModelOutputs, TEST_MODEL_OUTPUTS
+        )
+        model_outputs.datasets = []
+
+        # CALL
+        result = model_outputs.format_outputs()
+
+        # ASSERT
+        self.assertEqual(result, "No outputs")

--- a/test/workflows/test_workflow.py
+++ b/test/workflows/test_workflow.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import datetime
 from unittest import TestCase
 from unittest.mock import call, patch
@@ -220,8 +221,11 @@ class TestWorkflow(TestCase):
         # SETUP
         workflow: Workflow = parse_workflow(TEST_WORKFLOW)
 
-        # Two identical parameter sets
-        workflow.parameter_sets.append(workflow.parameter_sets[0])
+        # Two (almost) identical parameter sets
+        workflow.parameter_sets.append(copy.deepcopy(workflow.parameter_sets[0]))
+
+        workflow.parameter_sets[0].publication_date = datetime(2023, 4, 4)
+        workflow.parameter_sets[1].publication_date = datetime(2023, 2, 4)
 
         # CALL
         result = workflow.format_parameter_sets()
@@ -235,14 +239,20 @@ class TestWorkflow(TestCase):
                 TABLE_PUBLISHED_DATE_HEADER,
             ],
             rows=[
+                # Should have oldest first
+                [
+                    "0a0a0a0a-0a00-0a00-a000-0a0a0000000a",
+                    "First parameter set",
+                    "Joel Davies",
+                    "2023-02-04",
+                ],
                 [
                     "0a0a0a0a-0a00-0a00-a000-0a0a0000000a",
                     "First parameter set",
                     "Joel Davies",
                     "2023-04-04",
                 ],
-            ]
-            * 2,
+            ],
         )
         self.assertEqual(result, mock_format_table.return_value)
 


### PR DESCRIPTION
This adds some default sorting to tables largely to align with the front end:

- Sorts model input parameters and output files by their names (Alphabetically same as front end)
- Sorts workflow parameter sets by publication order (Newest last - opposite to front end)
- Sorts workflow instances by their finished date/time (Newest last - opposite to front end)
- Both the get workflows and get models commands already appear sorted by publication date (opposite to front end)
- get datasets  already uses S&D to show datasets with most recent first (same as front end)

I chose to go with the opposite datetime ordering to the front end as I think it makes more sense for the CLI to have the most recent at the bottom - this will be seen first by the user in a long list e.g. for get models, in contrast with the front end which will always load at the top of the page. It is simple enough to change though. The one caveat is 'get datasets' which is sorted the same as the front end due to the fact it uses S&D and there is no 'oldest' sorting option. I could just reverse the order but it also conflicts with the limit on the number of datasets and so I think it should be addressed with the pagination task.

Other notes
---
- Changes output of get models to state that there are no parameters, dataslots or outputs rather than printing nothing under their respective headings similar to #98