### PR TITLE
Add error messages to get workflow-instance output when present [CORE-3193]

### DIFF
--- a/dafni_cli/workflows/instance.py
+++ b/dafni_cli/workflows/instance.py
@@ -339,6 +339,12 @@ class WorkflowInstance(ParserBaseObject):
         click.echo(self.workflow_version.metadata.display_name)
         click.echo()
 
+        if self.workflow_version.spec.errors:
+            click.echo("Retrieving full Workflow failed. Messages:")
+            for error_msg in self.workflow_version.spec.errors:
+                click.echo(f"ERROR: {error_msg}")
+            click.echo()
+
         click.echo(
             tabulate(
                 [

--- a/dafni_cli/workflows/specification.py
+++ b/dafni_cli/workflows/specification.py
@@ -68,13 +68,19 @@ class WorkflowSpecification(ParserBaseObject):
     """Dataclass representing Workflows's specification
 
     Attributes:
+        errors (List[str]): List of any errors that occurred when fetching
+                            the data e.g. if a model doesn't have read
+                            permissions for the current user but is needed
+                            for a step
         steps (Dict[str, WorkflowSpecificationStep]): Dictionary of step
                                                       ID's and definitions
     """
 
+    errors: List[str]
     steps: Dict[str, WorkflowSpecificationStep]
 
     _parser_params: ClassVar[List[ParserParam]] = [
+        ParserParam("errors", "errors"),
         ParserParam(
             "steps",
             "steps",

--- a/dafni_cli/workflows/specification.py
+++ b/dafni_cli/workflows/specification.py
@@ -68,22 +68,22 @@ class WorkflowSpecification(ParserBaseObject):
     """Dataclass representing Workflows's specification
 
     Attributes:
-        errors (List[str]): List of any errors that occurred when fetching
+        steps (Dict[str, WorkflowSpecificationStep]): Dictionary of step
+                                                      ID's and definitions
+        errors (Optional[List[str]]): List of any errors that occurred when fetching
                             the data e.g. if a model doesn't have read
                             permissions for the current user but is needed
                             for a step
-        steps (Dict[str, WorkflowSpecificationStep]): Dictionary of step
-                                                      ID's and definitions
     """
 
-    errors: List[str]
     steps: Dict[str, WorkflowSpecificationStep]
+    errors: Optional[List[str]] = None
 
     _parser_params: ClassVar[List[ParserParam]] = [
-        ParserParam("errors", "errors"),
         ParserParam(
             "steps",
             "steps",
             parse_dict_retaining_keys(WorkflowSpecificationStep),
         ),
+        ParserParam("errors", "errors"),
     ]

--- a/test/fixtures/workflow_specification.py
+++ b/test/fixtures/workflow_specification.py
@@ -18,7 +18,6 @@ TEST_WORKFLOW_SPECIFICATION_DEFAULT = {
 }
 
 TEST_WORKFLOW_SPECIFICATION = {
-    "errors": ["Some error message"],
     "steps": {
         "0a0a0a0a-0a00-0a00-a000-0a0a0000000a": {
             "dependencies": ["0a0a0a0a-0a00-0a00-a000-0a0a0000000b"],

--- a/test/fixtures/workflow_specification.py
+++ b/test/fixtures/workflow_specification.py
@@ -18,6 +18,7 @@ TEST_WORKFLOW_SPECIFICATION_DEFAULT = {
 }
 
 TEST_WORKFLOW_SPECIFICATION = {
+    "errors": ["Some error message"],
     "steps": {
         "0a0a0a0a-0a00-0a00-a000-0a0a0000000a": {
             "dependencies": ["0a0a0a0a-0a00-0a00-a000-0a0a0000000b"],
@@ -150,5 +151,5 @@ TEST_WORKFLOW_SPECIFICATION = {
             "visualisation_description": "Test visualisation",
             "visualisation_title": "test-vis",
         },
-    }
+    },
 }

--- a/test/workflows/test_specification.py
+++ b/test/workflows/test_specification.py
@@ -88,6 +88,10 @@ class TestWorkflowSpecification(TestCase):
             )
         )
 
+        self.assertEqual(
+            workflow_specification.errors, TEST_WORKFLOW_SPECIFICATION["errors"]
+        )
+
         # WorkflowSpecificationStep (contents tested in TestWorkflowSpecificationStep)
         self.assertEqual(
             workflow_specification.steps.keys(),

--- a/test/workflows/test_specification.py
+++ b/test/workflows/test_specification.py
@@ -81,15 +81,11 @@ class TestWorkflowSpecification(TestCase):
     """Tests the WorkflowSpecification dataclass"""
 
     def test_parse(self):
-        """Tests parsing of WorkflowSpecificationStep"""
+        """Tests parsing of WorkflowSpecification"""
         workflow_specification: WorkflowSpecification = (
             ParserBaseObject.parse_from_dict(
                 WorkflowSpecification, TEST_WORKFLOW_SPECIFICATION
             )
-        )
-
-        self.assertEqual(
-            workflow_specification.errors, TEST_WORKFLOW_SPECIFICATION["errors"]
         )
 
         # WorkflowSpecificationStep (contents tested in TestWorkflowSpecificationStep)
@@ -99,3 +95,24 @@ class TestWorkflowSpecification(TestCase):
         )
         for step in workflow_specification.steps.values():
             self.assertEqual(type(step), WorkflowSpecificationStep)
+
+        self.assertEqual(workflow_specification.errors, None)
+
+    def test_parse_with_errors(self):
+        """Tests parsing of WorkflowSpecification when errors are defined"""
+        test_dict = TEST_WORKFLOW_SPECIFICATION.copy()
+        test_dict.update({"errors": ["Some test error"]})
+
+        workflow_specification: WorkflowSpecification = (
+            ParserBaseObject.parse_from_dict(WorkflowSpecification, test_dict)
+        )
+
+        # WorkflowSpecificationStep (contents tested in TestWorkflowSpecificationStep)
+        self.assertEqual(
+            workflow_specification.steps.keys(),
+            TEST_WORKFLOW_SPECIFICATION["steps"].keys(),
+        )
+        for step in workflow_specification.steps.values():
+            self.assertEqual(type(step), WorkflowSpecificationStep)
+
+        self.assertEqual(workflow_specification.errors, test_dict["errors"])


### PR DESCRIPTION
e.g.
![image](https://github.com/dafnifacility/cli/assets/90245114/74e0b6a3-8975-4538-866c-ff986d3af78c)
vs
![image](https://github.com/dafnifacility/cli/assets/90245114/c46d951f-22e7-452c-8091-8658385c5530)
