### PR TITLE
feat: Add --json flag to upload commands [CORE-3191]

### DIFF
--- a/dafni_cli/commands/get.py
+++ b/dafni_cli/commands/get.py
@@ -15,7 +15,7 @@ from dafni_cli.commands.helpers import (
     cli_get_workflow_instance,
     cli_get_workflow_parameter_set,
 )
-from dafni_cli.commands.options import filter_flag_option
+from dafni_cli.commands.options import filter_flag_option, json_option
 from dafni_cli.consts import (
     DATE_INPUT_FORMAT,
     DATE_INPUT_FORMAT_VERBOSE,
@@ -88,13 +88,7 @@ def get(ctx: Context):
     help=f"Filter for models published since given date. Format: {DATE_INPUT_FORMAT_VERBOSE}",
     type=click.DateTime(formats=[DATE_INPUT_FORMAT]),
 )
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def models(
     ctx: Context,
@@ -170,13 +164,7 @@ def models(
     default=False,
     help="Whether to display the version history of a model instead of the metadata. Default -m",
 )
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def model(ctx: Context, version_id: List[str], version_history: bool, json: bool):
     """Displays the metadata for one or more model versions
@@ -228,13 +216,7 @@ def model(ctx: Context, version_id: List[str], version_history: bool, json: bool
     help=f"Filter for datasets with a end date up to given date. Format: {DATE_INPUT_FORMAT_VERBOSE}",
     type=click.DateTime(formats=[DATE_INPUT_FORMAT]),
 )
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def datasets(
     ctx: Context,
@@ -268,12 +250,7 @@ def datasets(
 
 
 @get.command(help="Display metadata or version history of a particular dataset version")
-@click.option(
-    "--version-history/--metadata",
-    "-v/-m",
-    default=False,
-    help="Whether to display the version history of a dataset instead of the metadata. Default: -m",
-)
+@click.argument("version-id", nargs=1, required=True, type=str)
 @click.option(
     "--long/--short",
     "-l/-s",
@@ -282,13 +259,12 @@ def datasets(
     type=bool,
 )
 @click.option(
-    "--json/--pretty",
-    "-j/-p",
+    "--version-history/--metadata",
+    "-v/-m",
     default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
+    help="Whether to display the version history of a dataset instead of the metadata. Default: -m",
 )
-@click.argument("version-id", nargs=1, required=True, type=str)
+@json_option
 @click.pass_context
 def dataset(
     ctx: Context,
@@ -346,13 +322,7 @@ def dataset(
     help=f"Filter for workflows published since given date. Format: {DATE_INPUT_FORMAT_VERBOSE}",
     type=click.DateTime(formats=[DATE_INPUT_FORMAT]),
 )
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def workflows(
     ctx: Context,
@@ -425,13 +395,7 @@ def workflows(
     default=False,
     help="Whether to display the version history of a workflow instead of the metadata. Default -m",
 )
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def workflow(ctx: Context, version_id: List[str], version_history: bool, json: bool):
     """
@@ -489,13 +453,7 @@ def workflow(ctx: Context, version_id: List[str], version_history: bool, json: b
 @filter_flag_option("--omitted", help="Filters instances with an 'Omitted' status.")
 @filter_flag_option("--pending", help="Filters instances with a 'Pending' status.")
 @filter_flag_option("--running", help="Filters instances with a 'Running' status.")
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def workflow_instances(
     ctx: Context,
@@ -585,13 +543,7 @@ def workflow_instances(
 
 @get.command(help="Display information about a workflow instance")
 @click.argument("instance-id", required=True)
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def workflow_instance(
     ctx: Context,
@@ -619,13 +571,7 @@ def workflow_instance(
 @get.command(help="Display information about a workflow's parameter set")
 @click.argument("workflow-version-id", required=True)
 @click.argument("parameter-set-id", required=True)
-@click.option(
-    "--json/--pretty",
-    "-j/-p",
-    default=False,
-    help="Prints raw json returned from API. Default: -p",
-    type=bool,
-)
+@json_option
 @click.pass_context
 def workflow_parameter_set(
     ctx: Context,

--- a/dafni_cli/commands/options.py
+++ b/dafni_cli/commands/options.py
@@ -251,3 +251,20 @@ def filter_flag_option(*param_decls: str, help: str):
         return function
 
     return decorator
+
+
+def json_option(function):
+    """Decorator function for adding a --json click option for printing
+    json output
+
+    Flag will be named --json/--pretty and will be True or False
+    """
+    function = click.option(
+        "--json/--pretty",
+        "-j/-p",
+        default=False,
+        help="Prints raw json returned from API. Default: -p",
+        type=bool,
+    )(function)
+
+    return function

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -5,8 +5,8 @@ from typing import List, Optional, Tuple
 
 import click
 from click import Context
-from dafni_cli.api.exceptions import ValidationError
 
+from dafni_cli.api.exceptions import ValidationError
 from dafni_cli.api.session import DAFNISession
 from dafni_cli.api.workflows_api import (
     upload_parameter_set,
@@ -14,7 +14,7 @@ from dafni_cli.api.workflows_api import (
     validate_parameter_set_definition,
 )
 from dafni_cli.commands.helpers import cli_get_latest_dataset_metadata
-from dafni_cli.commands.options import dataset_metadata_common_options
+from dafni_cli.commands.options import dataset_metadata_common_options, json_option
 from dafni_cli.datasets.dataset_metadata import parse_dataset_metadata
 from dafni_cli.datasets.dataset_upload import (
     modify_dataset_metadata_for_upload,
@@ -64,6 +64,7 @@ def upload(ctx: Context):
     help="Parent ID of the parent model if this is an updated version of an existing model",
     default=None,
 )
+@json_option
 @click.pass_context
 def model(
     ctx: Context,
@@ -71,6 +72,7 @@ def model(
     image: Path,
     version_message: str,
     parent_id: Optional[str],
+    json: bool,
 ):
     """Uploads model to DAFNI from metadata and image files
 
@@ -80,19 +82,22 @@ def model(
         image (Path): File path to the image file
         version_message (str): Version message to be included with this model version
         parent_id (str): ID of the parent model that this is an update of
+        json (bool): Whether to print the raw json returned by the DAFNI API
     """
-    arguments = [
-        ("Model definition file path", definition),
-        ("Image file path", image),
-        ("Version message", version_message),
-    ]
-    confirmation_message = "Confirm model upload?"
-    if parent_id:
-        arguments.append(("Parent model ID", parent_id))
-        additional_message = None
-    else:
-        additional_message = ["No parent model: New model to be created"]
-    argument_confirmation(arguments, confirmation_message, additional_message)
+    # TODO: Modify once -y option added
+    if not json:
+        arguments = [
+            ("Model definition file path", definition),
+            ("Image file path", image),
+            ("Version message", version_message),
+        ]
+        confirmation_message = "Confirm model upload?"
+        if parent_id:
+            arguments.append(("Parent model ID", parent_id))
+            additional_message = None
+        else:
+            additional_message = ["No parent model: New model to be created"]
+        argument_confirmation(arguments, confirmation_message, additional_message)
 
     upload_model(
         ctx.obj["session"],
@@ -100,6 +105,7 @@ def model(
         image_path=image,
         version_message=version_message,
         parent_id=parent_id,
+        json=json,
     )
 
 

--- a/dafni_cli/commands/upload.py
+++ b/dafni_cli/commands/upload.py
@@ -86,22 +86,20 @@ def model(
         yes (bool): Used to skip confirmations before they are displayed
         json (bool): Whether to print the raw json returned by the DAFNI API
     """
-    # TODO: Modify once -y option added
-    if not json:
-        arguments = [
-            ("Model definition file path", definition),
-            ("Image file path", image),
-            ("Version message", version_message),
-        ]
-        confirmation_message = "Confirm model upload?"
-        if parent_id:
-            arguments.append(("Parent model ID", parent_id))
-            additional_message = None
-        else:
-            additional_message = ["No parent model: New model to be created"]
-        argument_confirmation(
-            arguments, confirmation_message, additional_message, yes=yes
-        )
+    arguments = [
+        ("Model definition file path", definition),
+        ("Image file path", image),
+        ("Version message", version_message),
+    ]
+    confirmation_message = "Confirm model upload?"
+    if parent_id:
+        arguments.append(("Parent model ID", parent_id))
+        additional_message = None
+    else:
+        additional_message = ["No parent model: New model to be created"]
+    argument_confirmation(
+        arguments, confirmation_message, additional_message, skip=yes or json
+    )
 
     upload_model(
         ctx.obj["session"],
@@ -148,14 +146,12 @@ def dataset(
         yes (bool): Used to skip confirmations before they are displayed
         json (bool): Whether to print the raw json returned by the DAFNI API
     """
-    # TODO: Modify once -y option added
-    if not json:
-        # Confirm upload details
-        arguments = [("Dataset metadata file path", metadata_path)] + [
-            ("Dataset file path", file) for file in files
-        ]
-        confirmation_message = "Confirm dataset upload?"
-        argument_confirmation(arguments, confirmation_message, yes=yes)
+    # Confirm upload details
+    arguments = [("Dataset metadata file path", metadata_path)] + [
+        ("Dataset file path", file) for file in files
+    ]
+    confirmation_message = "Confirm dataset upload?"
+    argument_confirmation(arguments, confirmation_message, skip=yes or json)
 
     # Obtain the metadata
     with open(metadata_path, "r", encoding="utf-8") as metadata_file:
@@ -274,20 +270,18 @@ def dataset_version(
 
         click.echo(f"Saved existing dataset metadata to {save}")
     else:
-        # TODO: Modify once -y option added
-        if not json:
-            # Confirm upload details
-            arguments = [
-                ("Dataset Title", dataset_metadata_obj.title),
-                ("Dataset ID", dataset_metadata_obj.dataset_id),
-                ("Dataset Version ID", dataset_metadata_obj.version_id),
-            ] + [("Dataset file path", file) for file in files]
+        # Confirm upload details
+        arguments = [
+            ("Dataset Title", dataset_metadata_obj.title),
+            ("Dataset ID", dataset_metadata_obj.dataset_id),
+            ("Dataset Version ID", dataset_metadata_obj.version_id),
+        ] + [("Dataset file path", file) for file in files]
 
-            if metadata:
-                arguments.append(("Dataset metadata file path", metadata))
+        if metadata:
+            arguments.append(("Dataset metadata file path", metadata))
 
-            confirmation_message = "Confirm dataset upload?"
-            argument_confirmation(arguments, confirmation_message, yes=yes)
+        confirmation_message = "Confirm dataset upload?"
+        argument_confirmation(arguments, confirmation_message, skip=yes or json)
 
         # Upload all files
         upload_dataset(
@@ -400,20 +394,18 @@ def dataset_metadata(
 
         click.echo(f"Saved existing dataset metadata to {save}")
     else:
-        # TODO: Modify once -y option added
-        if not json:
-            # Confirm upload details
-            arguments = [
-                ("Dataset Title", dataset_metadata_obj.title),
-                ("Dataset ID", dataset_metadata_obj.dataset_id),
-                ("Dataset Version ID", dataset_metadata_obj.version_id),
-            ]
+        # Confirm upload details
+        arguments = [
+            ("Dataset Title", dataset_metadata_obj.title),
+            ("Dataset ID", dataset_metadata_obj.dataset_id),
+            ("Dataset Version ID", dataset_metadata_obj.version_id),
+        ]
 
-            if metadata:
-                arguments.append(("Dataset metadata file path", metadata))
+        if metadata:
+            arguments.append(("Dataset metadata file path", metadata))
 
-            confirmation_message = "Confirm metadata upload?"
-            argument_confirmation(arguments, confirmation_message, yes=yes)
+        confirmation_message = "Confirm metadata upload?"
+        argument_confirmation(arguments, confirmation_message, skip=yes or json)
 
         # Upload
         upload_dataset_metadata_version(
@@ -472,21 +464,19 @@ def workflow(
         json (bool): Whether to print the raw json returned by the DAFNI API
     """
 
-    # TODO: Modify once -y option added
-    if not json:
-        arguments = [
-            ("Workflow definition file path", definition),
-            ("Version message", version_message),
-        ]
-        confirmation_message = "Confirm workflow upload?"
-        if parent_id:
-            arguments.append(("Parent workflow ID", parent_id))
-            additional_message = None
-        else:
-            additional_message = ["No parent workflow: new workflow to be created"]
-        argument_confirmation(
-            arguments, confirmation_message, additional_message, yes=yes
-        )
+    arguments = [
+        ("Workflow definition file path", definition),
+        ("Version message", version_message),
+    ]
+    confirmation_message = "Confirm workflow upload?"
+    if parent_id:
+        arguments.append(("Parent workflow ID", parent_id))
+        additional_message = None
+    else:
+        additional_message = ["No parent workflow: new workflow to be created"]
+    argument_confirmation(
+        arguments, confirmation_message, additional_message, skip=yes or json
+    )
 
     upload_workflow(
         ctx.obj["session"], definition, version_message, parent_id, json=json
@@ -518,12 +508,10 @@ def workflow_parameter_set(
         json (bool): Whether to print the raw json returned by the DAFNI API
     """
 
-    # TODO: Modify once -y option added
-    if not json:
-        arguments = [
-            ("Parameter set definition file path", definition),
-        ]
-        confirmation_message = "Confirm parameter set upload?"
-        argument_confirmation(arguments, confirmation_message, yes=yes)
+    arguments = [
+        ("Parameter set definition file path", definition),
+    ]
+    confirmation_message = "Confirm parameter set upload?"
+    argument_confirmation(arguments, confirmation_message, skip=yes or json)
 
     upload_parameter_set(ctx.obj["session"], definition, json=json)

--- a/dafni_cli/models/upload.py
+++ b/dafni_cli/models/upload.py
@@ -11,6 +11,7 @@ from dafni_cli.api.models_api import (
     validate_model_definition,
 )
 from dafni_cli.api.session import DAFNISession
+from dafni_cli.utils import optional_echo, print_json
 
 
 def upload_model(
@@ -19,6 +20,7 @@ def upload_model(
     image_path: Path,
     version_message: str,
     parent_id: Optional[str] = None,
+    json: bool = False,
 ):
     """Uploads a model to DAFNI
 
@@ -30,8 +32,10 @@ def upload_model(
         parent_id (Optional[str]): ID of a parent model. If given will upload
                                    a new version of the model, otherwise will
                                    upload a new model.
+        json (bool): Whether to print the raw json returned by the DAFNI API
     """
-    click.echo("Validating model definition")
+
+    optional_echo("Validating model definition", json)
     try:
         validate_model_definition(session, definition_path)
     except ValidationError as err:
@@ -39,18 +43,21 @@ def upload_model(
 
         raise SystemExit(1) from err
 
-    click.echo("Getting urls")
+    optional_echo("Getting urls", json)
     upload_id, urls = get_model_upload_urls(session)
     definition_url = urls["definition"]
     image_url = urls["image"]
 
-    click.echo("Uploading model definition and image")
+    optional_echo("Uploading model definition and image", json)
     upload_file_to_minio(session, definition_url, definition_path)
     upload_file_to_minio(session, image_url, image_path)
 
-    click.echo("Ingesting model")
+    optional_echo("Ingesting model", json)
     details = model_version_ingest(session, upload_id, version_message, parent_id)
 
     # Output details
-    click.echo("\nUpload successful")
-    click.echo(f"Version ID: {details['version_id']}")
+    if json:
+        print_json(details)
+    else:
+        click.echo("\nUpload successful")
+        click.echo(f"Version ID: {details['version_id']}")

--- a/dafni_cli/utils.py
+++ b/dafni_cli/utils.py
@@ -246,3 +246,10 @@ def construct_validation_errors_from_dict(dictionary: dict, prefix="") -> List[s
         else:
             errors.append(f"Error: ( {new_prefix} ) - {value}")
     return errors
+
+
+def optional_echo(string: str, should_not_print: bool):
+    """Uses click.echo to output a string only when should_not_print is False
+    (Used for optional printing for json flags)"""
+    if not should_not_print:
+        click.echo(string)

--- a/dafni_cli/utils.py
+++ b/dafni_cli/utils.py
@@ -69,7 +69,7 @@ def argument_confirmation(
     arguments: List[Tuple[str, str]],
     confirmation_message: str,
     additional_messages: Optional[List[str]] = None,
-    yes: bool = False,
+    skip: bool = False,
 ):
     """Function to display the arguments and options chosen by the user
     and ask for confirmation
@@ -81,12 +81,11 @@ def argument_confirmation(
                                     prompts the user to confirm or reject
         additional_messages (Optional[List[str]]): Other messages to be added
                                     after options are listed
-        yes (bool): Meant to correspond to the --yes command line option from
-                    confirmation_skip_option. A value of True skips the entire
-                    confirmation, whereas False will request input from the user
-                    after printing out any given messages.
+        skip (bool): Whether to skip the confirmation or not. A value of True
+                     skips the entire confirmation, whereas False will request
+                     input from the user after printing out any given messages
     """
-    if not yes:
+    if not skip:
         for name, value in arguments:
             click.echo(f"{name}: {value}")
         if additional_messages:

--- a/dafni_cli/workflows/upload.py
+++ b/dafni_cli/workflows/upload.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from typing import Optional
+
+import click
+
+import dafni_cli.api.workflows_api as workflows_api
+from dafni_cli.api.exceptions import ValidationError
+from dafni_cli.api.session import DAFNISession
+from dafni_cli.utils import optional_echo, print_json
+
+
+def upload_workflow(
+    session: DAFNISession,
+    definition: Path,
+    version_message: str,
+    parent_id: Optional[str] = None,
+    json: bool = False,
+):
+    """
+    Uploads a workflow in JSON form to DAFNI.
+
+    Args:
+        session (DAFNISession): User session
+        definition (Path): File path to the workflow definition file
+        version_message (str): Version message to be included with this workflow version
+        parent_id (str): ID of the parent workflow that this is an update of
+        json (bool): Whether to print the raw json returned by the DAFNI API
+    """
+
+    # TODO: Validate workflow definition using workflows/validate?
+
+    optional_echo("Uploading workflow", json)
+    details = workflows_api.upload_workflow(
+        session, definition, version_message, parent_id
+    )
+
+    if json:
+        print_json(details)
+    else:
+        click.echo("\nUpload successful")
+        click.echo(f"Version ID: {details['id']}")
+
+
+def upload_parameter_set(session: DAFNISession, definition: Path, json: bool = False):
+    """Uploads workflow parameter set to DAFNI
+
+    Args:
+        session (DAFNISession): User session
+        definition (Path): File path to the parameter set definition file
+        json (bool): Whether to print the raw json returned by the DAFNI API
+    """
+
+    optional_echo("Validating parameter set definition", json)
+    try:
+        workflows_api.validate_parameter_set_definition(session, definition)
+    except ValidationError as err:
+        click.echo(err)
+
+        raise SystemExit(1) from err
+
+    optional_echo("Uploading parameter set", json)
+    details = workflows_api.upload_parameter_set(session, definition)
+
+    # Output details
+    if json:
+        print_json(details)
+    else:
+        click.echo("\nUpload successful")
+        click.echo(f"Parameter set ID: {details['id']}")

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -250,7 +250,7 @@ class TestUploadDataset(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_dataset.assert_called_once_with(
-            session, {}, (Path("test_dataset.txt"),)
+            session, {}, (Path("test_dataset.txt"),), json=False
         )
 
         self.assertEqual(
@@ -299,6 +299,7 @@ class TestUploadDataset(TestCase):
             session,
             {},
             (Path("test_dataset1.txt"), Path("test_dataset2.txt")),
+            json=False,
         )
 
         self.assertEqual(
@@ -424,6 +425,7 @@ class TestUploadDatasetVersion(TestCase):
             dataset_id=metadata.dataset_id,
             metadata=mock_modify_dataset_metadata_for_upload.return_value,
             file_paths=(Path(file_path),),
+            json=False,
         )
 
         self.assertEqual(
@@ -500,6 +502,7 @@ class TestUploadDatasetVersion(TestCase):
             dataset_id=metadata.dataset_id,
             metadata=mock_modify_dataset_metadata_for_upload.return_value,
             file_paths=(Path(file_paths[0]), Path(file_paths[1])),
+            json=False,
         )
 
         self.assertEqual(
@@ -747,6 +750,7 @@ class TestUploadDatasetVersion(TestCase):
             dataset_id=metadata.dataset_id,
             metadata=mock_modify_dataset_metadata_for_upload.return_value,
             file_paths=(Path(file_path),),
+            json=False,
         )
 
         self.assertEqual(
@@ -829,6 +833,7 @@ class TestUploadDatasetMetadata(TestCase):
             dataset_id=metadata.dataset_id,
             version_id=dataset_version_id,
             metadata=mock_modify_dataset_metadata_for_upload.return_value,
+            json=False,
         )
 
         self.assertEqual(
@@ -993,6 +998,7 @@ class TestUploadDatasetMetadata(TestCase):
             dataset_id=metadata.dataset_id,
             version_id=dataset_version_id,
             metadata=mock_modify_dataset_metadata_for_upload.return_value,
+            json=False,
         )
 
         self.assertEqual(

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -94,6 +94,7 @@ class TestUploadModel(TestCase):
             image_path=Path(image_path),
             version_message=version_message,
             parent_id=None,
+            json=False,
         )
 
         self.assertEqual(
@@ -151,6 +152,7 @@ class TestUploadModel(TestCase):
             image_path=Path(image_path),
             version_message=version_message,
             parent_id=parent_id,
+            json=False,
         )
 
         self.assertEqual(

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -1098,8 +1098,6 @@ class TestUploadWorkflow(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         version_message = "Initial version"
-        version_id = "version-id"
-        mock_upload_workflow.return_value = {"id": version_id}
 
         # CALL
         with runner.isolated_filesystem():
@@ -1119,7 +1117,7 @@ class TestUploadWorkflow(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_workflow.assert_called_once_with(
-            session, Path("test_definition.json"), version_message, None
+            session, Path("test_definition.json"), version_message, None, json=False
         )
 
         self.assertEqual(
@@ -1127,10 +1125,7 @@ class TestUploadWorkflow(TestCase):
             "Workflow definition file path: test_definition.json\n"
             f"Version message: {version_message}\n"
             "No parent workflow: new workflow to be created\n"
-            "Confirm workflow upload? [y/N]: y\n"
-            "Uploading workflow\n"
-            "\nUpload successful\n"
-            f"Version ID: {version_id}\n",
+            "Confirm workflow upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
@@ -1147,8 +1142,6 @@ class TestUploadWorkflow(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         version_message = "Initial version"
-        version_id = "version-id"
-        mock_upload_workflow.return_value = {"id": version_id}
 
         # CALL
         with runner.isolated_filesystem():
@@ -1170,7 +1163,11 @@ class TestUploadWorkflow(TestCase):
         # ASSERT
         mock_DAFNISession.assert_called_once()
         mock_upload_workflow.assert_called_once_with(
-            session, Path("test_definition.json"), version_message, "parent-id"
+            session,
+            Path("test_definition.json"),
+            version_message,
+            "parent-id",
+            json=False,
         )
 
         self.assertEqual(
@@ -1178,10 +1175,7 @@ class TestUploadWorkflow(TestCase):
             "Workflow definition file path: test_definition.json\n"
             f"Version message: {version_message}\n"
             "Parent workflow ID: parent-id\n"
-            "Confirm workflow upload? [y/N]: y\n"
-            "Uploading workflow\n"
-            "\nUpload successful\n"
-            f"Version ID: {version_id}\n",
+            "Confirm workflow upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
@@ -1197,8 +1191,6 @@ class TestUploadWorkflow(TestCase):
         mock_DAFNISession.return_value = session
         runner = CliRunner()
         version_message = "Initial version"
-        version_id = "version-id"
-        mock_upload_workflow.return_value = {"id": version_id}
 
         # CALL
         with runner.isolated_filesystem():
@@ -1231,7 +1223,6 @@ class TestUploadWorkflow(TestCase):
 
 
 @patch("dafni_cli.commands.upload.DAFNISession")
-@patch("dafni_cli.commands.upload.validate_parameter_set_definition")
 @patch("dafni_cli.commands.upload.upload_parameter_set")
 class TestUploadWorkflowParameterSet(TestCase):
     """Test class to test the upload workflow-parameter-set commands"""
@@ -1239,7 +1230,6 @@ class TestUploadWorkflowParameterSet(TestCase):
     def test_upload_workflow_parameter_set(
         self,
         mock_upload_parameter_set,
-        mock_validate_parameter_set_definition,
         mock_DAFNISession,
     ):
         """Tests that the 'upload workflow-parameter-set' command works
@@ -1267,73 +1257,20 @@ class TestUploadWorkflowParameterSet(TestCase):
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_validate_parameter_set_definition.assert_called_once_with(
-            session, Path("test_definition.json")
-        )
         mock_upload_parameter_set.assert_called_once_with(
-            session, Path("test_definition.json")
+            session, Path("test_definition.json"), json=False
         )
 
         self.assertEqual(
             result.output,
             "Parameter set definition file path: test_definition.json\n"
             "Confirm parameter set upload? [y/N]: y\n"
-            "Validating parameter set definition\n"
-            "Uploading parameter set\n"
-            "\nUpload successful\n"
-            f"Parameter set ID: {parameter_set_id}\n",
         )
         self.assertEqual(result.exit_code, 0)
-
-    def test_upload_workflow_parameter_set_validation_error(
-        self,
-        mock_upload_parameter_set,
-        mock_validate_parameter_set_definition,
-        mock_DAFNISession,
-    ):
-        """Tests that the 'upload workflow-parameter-set' command works
-        correctly when a ValidationError occurs"""
-
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        error = ValidationError("Some error message")
-        mock_validate_parameter_set_definition.side_effect = error
-
-        # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "workflow-parameter-set",
-                    "test_definition.json",
-                ],
-                input="y",
-            )
-
-        # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_validate_parameter_set_definition.assert_called_once_with(
-            session, Path("test_definition.json")
-        )
-        mock_upload_parameter_set.assert_not_called()
-
-        self.assertEqual(
-            result.output,
-            "Parameter set definition file path: test_definition.json\n"
-            "Confirm parameter set upload? [y/N]: y\n"
-            "Validating parameter set definition\n"
-            f"{str(error)}\n",
-        )
-        self.assertEqual(result.exit_code, 1)
 
     def test_upload_workflow_parameter_set_cancel(
         self,
         mock_upload_parameter_set,
-        mock_validate_parameter_set_definition,
         mock_DAFNISession,
     ):
         """Tests that the 'upload workflow-parameter-set' command can be canceled"""
@@ -1342,8 +1279,6 @@ class TestUploadWorkflowParameterSet(TestCase):
         session = MagicMock()
         mock_DAFNISession.return_value = session
         runner = CliRunner()
-        parameter_set_id = "parameter-set-id"
-        mock_upload_parameter_set.return_value = {"id": parameter_set_id}
 
         # CALL
         with runner.isolated_filesystem():
@@ -1360,7 +1295,6 @@ class TestUploadWorkflowParameterSet(TestCase):
 
         # ASSERT
         mock_DAFNISession.assert_called_once()
-        mock_validate_parameter_set_definition.assert_not_called()
         mock_upload_parameter_set.assert_not_called()
 
         self.assertEqual(

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -68,14 +68,16 @@ class TestUploadModel(TestCase):
 
     def invoke_command(
         self,
-        additional_params: List[str] = None,
+        additional_args: Optional[List[str]] = None,
         input: Optional[str] = None,
     ) -> Result:
-        """Invokes the upload model command with required arguments provided,
-        any 'additional_params' are added, and input is passed through to the
-        CliRunner.invoke call"""
-        if additional_params is None:
-            additional_params = []
+        """Invokes the upload model command with required arguments provided
+        Args:
+            additional_args (Optional[List[str]]): Any additional parameters to add
+            input (Optional[str]): 'input' to pass to CliRunner's invoke function
+        """
+        if additional_args is None:
+            additional_args = []
 
         runner = CliRunner()
 
@@ -93,7 +95,7 @@ class TestUploadModel(TestCase):
                     "--version-message",
                     self.version_message,
                 ]
-                + additional_params,
+                + additional_args,
                 input=input,
             )
         return result
@@ -138,7 +140,7 @@ class TestUploadModel(TestCase):
 
         # CALL
         result = self.invoke_command(
-            additional_params=["--parent-id", self.parent_id],
+            additional_args=["--parent-id", self.parent_id],
             input="y",
         )
 
@@ -171,7 +173,7 @@ class TestUploadModel(TestCase):
 
         # CALL
         result = self.invoke_command(
-            additional_params=["-y"],
+            additional_args=["-y"],
         )
 
         # ASSERT
@@ -196,7 +198,7 @@ class TestUploadModel(TestCase):
 
         # CALL
         result = self.invoke_command(
-            additional_params=["--json"],
+            additional_args=["--json"],
         )
 
         # ASSERT
@@ -239,131 +241,159 @@ class TestUploadModel(TestCase):
         self.assertEqual(result.exit_code, 1)
 
 
-@patch("dafni_cli.commands.upload.DAFNISession")
-@patch("dafni_cli.commands.upload.upload_dataset")
 class TestUploadDataset(TestCase):
     """Test class to test the upload dataset commands"""
 
-    def test_upload_dataset(
-        self,
-        mock_upload_dataset,
-        mock_DAFNISession,
-    ):
-        """Tests that the 'upload dataset' command works correctly"""
+    def setUp(self) -> None:
+        super().setUp()
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
+        self.metadata_path = "test_metadata.json"
+
+        self.mock_DAFNISession = patch("dafni_cli.commands.upload.DAFNISession").start()
+        self.mock_session = MagicMock()
+        self.mock_DAFNISession.return_value = self.mock_session
+
+        self.mock_upload_dataset = patch(
+            "dafni_cli.commands.upload.upload_dataset"
+        ).start()
+
+        self.addCleanup(patch.stopall)
+
+    def invoke_command(
+        self,
+        file_paths: List[str],
+        additional_args: Optional[List[str]] = None,
+        input: Optional[str] = None,
+    ) -> Result:
+        """Invokes the upload dataset command with most required arguments provided
+
+        Args:
+            file_paths (Optional[List]): List of file paths of the dataset files
+                                         to upload (Added automatically to command
+                                         parameters)
+            additional_args (Optional[List[str]]): Any additional parameters to
+                                                   add
+            input (Optional[str]): 'input' to pass to CliRunner's invoke function
+        """
+        if additional_args is None:
+            additional_args = []
+
         runner = CliRunner()
 
-        # CALL
         with runner.isolated_filesystem():
-            with open("test_metadata.json", "w", encoding="utf-8") as file:
+            with open(self.metadata_path, "w", encoding="utf-8") as file:
                 file.write("{}")
-            with open("test_dataset.txt", "w", encoding="utf-8") as file:
-                file.write("test dataset file")
+            for file_path in file_paths:
+                with open(file_path, "w", encoding="utf-8") as file:
+                    file.write("test dataset file")
             result = runner.invoke(
                 upload.upload,
                 [
                     "dataset",
-                    "test_metadata.json",
-                    "test_dataset.txt",
-                ],
-                input="y",
+                    self.metadata_path,
+                ]
+                + file_paths
+                + additional_args,
+                input=input,
             )
+        return result
+
+    def test_upload_dataset(
+        self,
+    ):
+        """Tests that the 'upload dataset' command works correctly"""
+
+        # SETUP
+        dataset_file_path = "test_dataset.txt"
+
+        # CALL
+        result = self.invoke_command(file_paths=[dataset_file_path], input="y")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_dataset.assert_called_once_with(
-            session, {}, (Path("test_dataset.txt"),), json=False
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session, {}, (Path(dataset_file_path),), json=False
         )
 
         self.assertEqual(
             result.output,
-            "Dataset metadata file path: test_metadata.json\n"
-            "Dataset file path: test_dataset.txt\n"
+            f"Dataset metadata file path: {self.metadata_path}\n"
+            f"Dataset file path: {dataset_file_path}\n"
             "Confirm dataset upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
     def test_upload_dataset_with_multiple_files(
         self,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset' command works correctly when
         multiple files are given"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
+        dataset_file_paths = ["test_dataset1.txt", "test_dataset2.txt"]
 
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_metadata.json", "w", encoding="utf-8") as file:
-                file.write("{}")
-            with open("test_dataset1.txt", "w", encoding="utf-8") as file:
-                file.write("test dataset file1")
-            with open("test_dataset2.txt", "w", encoding="utf-8") as file:
-                file.write("test dataset file2")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "dataset",
-                    "test_metadata.json",
-                    "test_dataset1.txt",
-                    "test_dataset2.txt",
-                ],
-                input="y",
-            )
+        result = self.invoke_command(file_paths=dataset_file_paths, input="y")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_dataset.assert_called_once_with(
-            session,
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session,
             {},
-            (Path("test_dataset1.txt"), Path("test_dataset2.txt")),
+            (Path(dataset_file_paths[0]), Path(dataset_file_paths[1])),
             json=False,
         )
 
         self.assertEqual(
             result.output,
-            "Dataset metadata file path: test_metadata.json\n"
-            "Dataset file path: test_dataset1.txt\n"
-            "Dataset file path: test_dataset2.txt\n"
+            f"Dataset metadata file path: {self.metadata_path}\n"
+            f"Dataset file path: {dataset_file_paths[0]}\n"
+            f"Dataset file path: {dataset_file_paths[1]}\n"
             "Confirm dataset upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
     def test_upload_dataset_skipping_confirmation(
         self,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset' command works correctly when
         given a -y flag to skip the confirmation"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
+        dataset_file_path = "test_dataset.txt"
 
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_metadata.json", "w", encoding="utf-8") as file:
-                file.write("{}")
-            with open("test_dataset.txt", "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            result = runner.invoke(
-                upload.upload,
-                ["dataset", "test_metadata.json", "test_dataset.txt", "-y"],
-            )
+        result = self.invoke_command(
+            file_paths=[dataset_file_path], additional_args=["-y"], input="y"
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_dataset.assert_called_once_with(
-            session, {}, (Path("test_dataset.txt"),), json=False
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session, {}, (Path(dataset_file_path),), json=False
+        )
+
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_upload_dataset_json(
+        self,
+    ):
+        """Tests that the 'upload dataset' command works correctly when given
+        a --json flag"""
+
+        # SETUP
+        dataset_file_path = "test_dataset.txt"
+
+        # CALL
+        result = self.invoke_command(
+            file_paths=[dataset_file_path], additional_args=["--json"]
+        )
+
+        # ASSERT
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session, {}, (Path(dataset_file_path),), json=True
         )
 
         self.assertEqual(result.output, "")
@@ -371,91 +401,124 @@ class TestUploadDataset(TestCase):
 
     def test_upload_dataset_cancel(
         self,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset' command can be canceled"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
+        dataset_file_path = "test_dataset.txt"
 
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_metadata.json", "w", encoding="utf-8") as file:
-                file.write("{}")
-            with open("test_dataset.txt", "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "dataset",
-                    "test_metadata.json",
-                    "test_dataset.txt",
-                ],
-                input="n",
-            )
+        result = self.invoke_command(file_paths=[dataset_file_path], input="n")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_dataset.assert_not_called()
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_dataset.assert_not_called()
 
         self.assertEqual(
             result.output,
-            "Dataset metadata file path: test_metadata.json\n"
-            "Dataset file path: test_dataset.txt\n"
+            f"Dataset metadata file path: {self.metadata_path}\n"
+            f"Dataset file path: {dataset_file_path}\n"
             "Confirm dataset upload? [y/N]: n\n"
             "Aborted!\n",
         )
         self.assertEqual(result.exit_code, 1)
 
 
-@patch("dafni_cli.commands.upload.DAFNISession")
-@patch("dafni_cli.commands.upload.upload_dataset")
-@patch("dafni_cli.commands.upload.cli_get_latest_dataset_metadata")
-@patch("dafni_cli.commands.upload.modify_dataset_metadata_for_upload")
 class TestUploadDatasetVersion(TestCase):
     """Test class to test the upload dataset-version commands"""
 
-    def test_upload_dataset_version(
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.dataset_version_id = "some-existing-version-id"
+
+        self.mock_DAFNISession = patch("dafni_cli.commands.upload.DAFNISession").start()
+        self.mock_session = MagicMock()
+        self.mock_DAFNISession.return_value = self.mock_session
+
+        self.mock_cli_get_latest_dataset_metadata = patch(
+            "dafni_cli.commands.upload.cli_get_latest_dataset_metadata"
+        ).start()
+        self.mock_modify_dataset_metadata_for_upload = patch(
+            "dafni_cli.commands.upload.modify_dataset_metadata_for_upload"
+        ).start()
+        self.mock_upload_dataset = patch(
+            "dafni_cli.commands.upload.upload_dataset"
+        ).start()
+
+        self.addCleanup(patch.stopall)
+
+    def invoke_command(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset,
-        mock_DAFNISession,
-    ):
-        """Tests that the 'upload dataset-version' command works correctly"""
+        file_paths: List[str],
+        additional_args: Optional[List[str]] = None,
+        input: Optional[str] = None,
+        file_paths_to_read: Optional[List[str]] = None,
+    ) -> Tuple[Result, List[str]]:
+        """Invokes the upload dataset-version  command with most required arguments
+        provided
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
+        Args:
+            file_paths (Optional[List]): List of file paths of files to create prior
+                                         to invoking the command
+            additional_args (Optional[List[str]]): Any additional parameters to
+                                                     add
+            input (Optional[str]): 'input' to pass to CliRunner's invoke function
+            file_paths_to_read (Optional[List[str]]): Paths to files to read (will
+                                                    return the contents in a list)
+        """
+        if additional_args is None:
+            additional_args = []
+
         runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        file_path = "test_dataset.txt"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
-        metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
-        # CALL
+        saved_file_data = []
+
         with runner.isolated_filesystem():
-            with open("test_dataset.txt", "w", encoding="utf-8") as file:
-                file.write("test dataset file")
+            for file_path in file_paths:
+                with open(file_path, "w", encoding="utf-8") as file:
+                    file.write("test dataset file")
             result = runner.invoke(
                 upload.upload,
                 [
                     "dataset-version",
-                    dataset_version_id,
-                    file_path,
-                ],
-                input="y",
+                    self.dataset_version_id,
+                ]
+                + additional_args,
+                input=input,
             )
+            # Store the contents of any files created so they may be checked
+            # later
+            if file_paths_to_read:
+                for file_path in file_paths_to_read:
+                    with open(file_path, "r", encoding="utf-8") as file:
+                        saved_file_data.append(file.read())
+
+        return result, saved_file_data
+
+    def test_upload_dataset_version(
+        self,
+    ):
+        """Tests that the 'upload dataset-version' command works correctly"""
+
+        # SETUP
+        dataset_file_path = "test_dataset.txt"
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
+
+        # CALL
+        result, _ = self.invoke_command(
+            file_paths=[dataset_file_path],
+            additional_args=[dataset_file_path],
+            input="y",
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -478,11 +541,11 @@ class TestUploadDatasetVersion(TestCase):
             rights=None,
             version_message=None,
         )
-        mock_upload_dataset.assert_called_once_with(
-            session,
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session,
             dataset_id=metadata.dataset_id,
-            metadata=mock_modify_dataset_metadata_for_upload.return_value,
-            file_paths=(Path(file_path),),
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
+            file_paths=(Path(dataset_file_path),),
             json=False,
         )
 
@@ -491,48 +554,35 @@ class TestUploadDatasetVersion(TestCase):
             f"Dataset Title: {metadata.title}\n"
             f"Dataset ID: {metadata.dataset_id}\n"
             f"Dataset Version ID: {metadata.version_id}\n"
-            f"Dataset file path: {file_path}\n"
+            f"Dataset file path: {dataset_file_path}\n"
             "Confirm dataset upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
     def test_upload_dataset_version_with_multiple_files(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-version' command works correctly
         when multiple files are given"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        file_paths = ["test_dataset1.txt", "test_dataset2.txt"]
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        dataset_file_paths = ["test_dataset1.txt", "test_dataset2.txt"]
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         # CALL
-        with runner.isolated_filesystem():
-            with open(file_paths[0], "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            with open(file_paths[1], "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            result = runner.invoke(
-                upload.upload,
-                ["dataset-version", dataset_version_id, file_paths[0], file_paths[1]],
-                input="y",
-            )
+        result, _ = self.invoke_command(
+            file_paths=dataset_file_paths,
+            additional_args=dataset_file_paths,
+            input="y",
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -555,11 +605,11 @@ class TestUploadDatasetVersion(TestCase):
             rights=None,
             version_message=None,
         )
-        mock_upload_dataset.assert_called_once_with(
-            session,
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session,
             dataset_id=metadata.dataset_id,
-            metadata=mock_modify_dataset_metadata_for_upload.return_value,
-            file_paths=(Path(file_paths[0]), Path(file_paths[1])),
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
+            file_paths=(Path(dataset_file_paths[0]), Path(dataset_file_paths[1])),
             json=False,
         )
 
@@ -568,56 +618,40 @@ class TestUploadDatasetVersion(TestCase):
             f"Dataset Title: {metadata.title}\n"
             f"Dataset ID: {metadata.dataset_id}\n"
             f"Dataset Version ID: {metadata.version_id}\n"
-            f"Dataset file path: {file_paths[0]}\n"
-            f"Dataset file path: {file_paths[1]}\n"
+            f"Dataset file path: {dataset_file_paths[0]}\n"
+            f"Dataset file path: {dataset_file_paths[1]}\n"
             "Confirm dataset upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
     def test_upload_dataset_version_saving_existing_metadata(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-version' command works correctly
         with the --save option"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        file_path = "test_dataset.txt"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
-        mock_modify_dataset_metadata_for_upload.return_value = TEST_DATASET_METADATA
+        dataset_file_path = "test_dataset.txt"
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        self.mock_modify_dataset_metadata_for_upload.return_value = (
+            TEST_DATASET_METADATA
+        )
         metadata_save_path = "metadata_save_file.json"
 
         # CALL
-        with runner.isolated_filesystem():
-            with open(file_path, "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "dataset-version",
-                    dataset_version_id,
-                    file_path,
-                    "--save",
-                    metadata_save_path,
-                ],
-            )
-
-            with open(metadata_save_path, "r", encoding="utf-8") as file:
-                saved_metadata = file.read()
+        result, saved_file_data = self.invoke_command(
+            file_paths=[dataset_file_path],
+            additional_args=[dataset_file_path, "--save", metadata_save_path],
+            input="y",
+            file_paths_to_read=[metadata_save_path],
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -641,9 +675,10 @@ class TestUploadDatasetVersion(TestCase):
             version_message=None,
         )
         self.assertEqual(
-            saved_metadata, json.dumps(TEST_DATASET_METADATA, indent=4, sort_keys=True)
+            saved_file_data[0],
+            json.dumps(TEST_DATASET_METADATA, indent=4, sort_keys=True),
         )
-        mock_upload_dataset.assert_not_called()
+        self.mock_upload_dataset.assert_not_called()
 
         self.assertEqual(
             result.output, f"Saved existing dataset metadata to {metadata_save_path}\n"
@@ -652,38 +687,26 @@ class TestUploadDatasetVersion(TestCase):
 
     def test_upload_dataset_version_skipping_confirmation(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-version' command works correctly when
         given a -y flag to skip the confirmation"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        file_path = "test_dataset.txt"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        dataset_file_path = "test_dataset.txt"
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_dataset.txt", "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            result = runner.invoke(
-                upload.upload,
-                ["dataset-version", dataset_version_id, file_path, "-y"],
-            )
+        result, _ = self.invoke_command(
+            file_paths=[dataset_file_path], additional_args=[dataset_file_path, "-y"]
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -706,12 +729,68 @@ class TestUploadDatasetVersion(TestCase):
             rights=None,
             version_message=None,
         )
-        mock_upload_dataset.assert_called_once_with(
-            session,
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session,
             dataset_id=metadata.dataset_id,
-            metadata=mock_modify_dataset_metadata_for_upload.return_value,
-            file_paths=(Path(file_path),),
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
+            file_paths=(Path(dataset_file_path),),
             json=False,
+        )
+
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_upload_dataset_version_json(
+        self,
+    ):
+        """Tests that the 'upload dataset-version' command works correctly
+        when given a --json flag"""
+
+        # SETUP
+        dataset_file_path = "test_dataset.txt"
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
+
+        # CALL
+        result, _ = self.invoke_command(
+            file_paths=[dataset_file_path],
+            additional_args=[dataset_file_path, "--json"],
+        )
+
+        # ASSERT
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
+        )
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+            existing_metadata=TEST_DATASET_METADATA,
+            metadata_path=None,
+            title=None,
+            description=None,
+            subject=None,
+            identifiers=None,
+            themes=None,
+            language=None,
+            keywords=None,
+            standard=None,
+            start_date=None,
+            end_date=None,
+            organisation=None,
+            people=None,
+            created_date=None,
+            update_frequency=None,
+            publisher=None,
+            contact=None,
+            license=None,
+            rights=None,
+            version_message=None,
+        )
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session,
+            dataset_id=metadata.dataset_id,
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
+            file_paths=(Path(dataset_file_path),),
+            json=True,
         )
 
         self.assertEqual(result.output, "")
@@ -719,42 +798,27 @@ class TestUploadDatasetVersion(TestCase):
 
     def test_upload_dataset_version_cancel(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-version' command can be canceled"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        file_path = "test_dataset.txt"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        dataset_file_path = "test_dataset.txt"
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         # CALL
-        with runner.isolated_filesystem():
-            with open(file_path, "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "dataset-version",
-                    dataset_version_id,
-                    file_path,
-                ],
-                input="n",
-            )
+        result, _ = self.invoke_command(
+            file_paths=[dataset_file_path],
+            additional_args=[dataset_file_path],
+            input="n",
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -777,14 +841,14 @@ class TestUploadDatasetVersion(TestCase):
             rights=None,
             version_message=None,
         )
-        mock_upload_dataset.assert_not_called()
+        self.mock_upload_dataset.assert_not_called()
 
         self.assertEqual(
             result.output,
             f"Dataset Title: {metadata.title}\n"
             f"Dataset ID: {metadata.dataset_id}\n"
             f"Dataset Version ID: {metadata.version_id}\n"
-            f"Dataset file path: {file_path}\n"
+            f"Dataset file path: {dataset_file_path}\n"
             "Confirm dataset upload? [y/N]: n\n"
             "Aborted!\n",
         )
@@ -792,22 +856,14 @@ class TestUploadDatasetVersion(TestCase):
 
     def test_upload_dataset_version_with_metadata_and_all_optional_modifications(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-version' command works correctly
         when a path to metadata and a version message is given"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        file_path = "test_dataset.txt"
+        dataset_file_path = "test_dataset.txt"
         metadata_path = "definition.json"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         options = {
@@ -835,11 +891,9 @@ class TestUploadDatasetVersion(TestCase):
             "version_message": "Some version message",
         }
 
-        args = add_dataset_metadata_common_options(
+        additional_args = add_dataset_metadata_common_options(
             args=[
-                "dataset-version",
-                dataset_version_id,
-                file_path,
+                dataset_file_path,
                 "--metadata",
                 metadata_path,
             ],
@@ -849,32 +903,27 @@ class TestUploadDatasetVersion(TestCase):
         )
 
         # CALL
-        with runner.isolated_filesystem():
-            with open(file_path, "w", encoding="utf-8") as file:
-                file.write("test dataset file")
-            with open(metadata_path, "w", encoding="utf-8") as file:
-                file.write("test metadata file")
-            result = runner.invoke(
-                upload.upload,
-                args,
-                input="y",
-            )
+        result, _ = self.invoke_command(
+            file_paths=[dataset_file_path, metadata_path],
+            additional_args=additional_args,
+            input="y",
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=Path(metadata_path),
             **options,
         )
-        mock_upload_dataset.assert_called_once_with(
-            session,
+        self.mock_upload_dataset.assert_called_once_with(
+            self.mock_session,
             dataset_id=metadata.dataset_id,
-            metadata=mock_modify_dataset_metadata_for_upload.return_value,
-            file_paths=(Path(file_path),),
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
+            file_paths=(Path(dataset_file_path),),
             json=False,
         )
 
@@ -883,54 +932,103 @@ class TestUploadDatasetVersion(TestCase):
             f"Dataset Title: {metadata.title}\n"
             f"Dataset ID: {metadata.dataset_id}\n"
             f"Dataset Version ID: {metadata.version_id}\n"
-            f"Dataset file path: {file_path}\n"
+            f"Dataset file path: {dataset_file_path}\n"
             f"Dataset metadata file path: {metadata_path}\n"
             "Confirm dataset upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
 
-@patch("dafni_cli.commands.upload.DAFNISession")
-@patch("dafni_cli.commands.upload.upload_dataset_metadata_version")
-@patch("dafni_cli.commands.upload.cli_get_latest_dataset_metadata")
-@patch("dafni_cli.commands.upload.modify_dataset_metadata_for_upload")
 class TestUploadDatasetMetadata(TestCase):
     """Test class to test the upload dataset-metadata commands"""
 
-    def test_upload_dataset_metadata(
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.dataset_version_id = "some-existing-version-id"
+
+        self.mock_DAFNISession = patch("dafni_cli.commands.upload.DAFNISession").start()
+        self.mock_session = MagicMock()
+        self.mock_DAFNISession.return_value = self.mock_session
+
+        self.mock_cli_get_latest_dataset_metadata = patch(
+            "dafni_cli.commands.upload.cli_get_latest_dataset_metadata"
+        ).start()
+        self.mock_modify_dataset_metadata_for_upload = patch(
+            "dafni_cli.commands.upload.modify_dataset_metadata_for_upload"
+        ).start()
+        self.mock_upload_dataset_metadata_version = patch(
+            "dafni_cli.commands.upload.upload_dataset_metadata_version"
+        ).start()
+
+    def invoke_command(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset_metadata_version,
-        mock_DAFNISession,
-    ):
-        """Tests that the 'upload dataset-metadata' command works correctly"""
+        file_paths: Optional[List[str]] = None,
+        additional_args: Optional[List[str]] = None,
+        input: Optional[str] = None,
+        file_paths_to_read: Optional[List[str]] = None,
+    ) -> Tuple[Result, List[str]]:
+        """Invokes the upload dataset-metadata command with the required arguments
+        provided
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
+        Args:
+            file_paths (Optional[List]): List of file paths of files to create prior
+                                         to invoking the command
+            additional_args (Optional[List[str]]): Any additional parameters to
+                                                     add
+            input (Optional[str]): 'input' to pass to CliRunner's invoke function
+            file_paths_to_read (Optional[List[str]]): Paths to files to read (will
+                                                    return the contents in a list)
+        """
+        if file_paths is None:
+            file_paths = []
+        if additional_args is None:
+            additional_args = []
+
         runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
-        metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
-        # CALL
+        saved_file_data = []
+
         with runner.isolated_filesystem():
+            for file_path in file_paths:
+                with open(file_path, "w", encoding="utf-8") as file:
+                    file.write("test dataset file")
             result = runner.invoke(
                 upload.upload,
                 [
                     "dataset-metadata",
-                    dataset_version_id,
-                ],
-                input="y",
+                    self.dataset_version_id,
+                ]
+                + additional_args,
+                input=input,
             )
+            # Store the contents of any files created so they may be checked
+            # later
+            if file_paths_to_read:
+                for file_path in file_paths_to_read:
+                    with open(file_path, "r", encoding="utf-8") as file:
+                        saved_file_data.append(file.read())
+
+        return result, saved_file_data
+
+    def test_upload_dataset_metadata(
+        self,
+    ):
+        """Tests that the 'upload dataset-metadata' command works correctly"""
+
+        # SETUP
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
+
+        # CALL
+        result, _ = self.invoke_command(input="y")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -953,11 +1051,11 @@ class TestUploadDatasetMetadata(TestCase):
             rights=None,
             version_message=None,
         )
-        mock_upload_dataset_metadata_version.assert_called_once_with(
-            session,
+        self.mock_upload_dataset_metadata_version.assert_called_once_with(
+            self.mock_session,
             dataset_id=metadata.dataset_id,
-            version_id=dataset_version_id,
-            metadata=mock_modify_dataset_metadata_for_upload.return_value,
+            version_id=self.dataset_version_id,
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
             json=False,
         )
 
@@ -972,44 +1070,29 @@ class TestUploadDatasetMetadata(TestCase):
 
     def test_upload_dataset_metadata_saving_existing_metadata(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset_metadata_version,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-metadata' command works correctly
         with the --save option"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
-        mock_modify_dataset_metadata_for_upload.return_value = TEST_DATASET_METADATA
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        self.mock_modify_dataset_metadata_for_upload.return_value = (
+            TEST_DATASET_METADATA
+        )
         metadata_save_path = "metadata_save_file.json"
 
         # CALL
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "dataset-metadata",
-                    dataset_version_id,
-                    "--save",
-                    metadata_save_path,
-                ],
-            )
-
-            with open(metadata_save_path, "r", encoding="utf-8") as file:
-                saved_metadata = file.read()
+        result, saved_file_data = self.invoke_command(
+            additional_args=["--save", metadata_save_path],
+            file_paths_to_read=[metadata_save_path],
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -1033,9 +1116,10 @@ class TestUploadDatasetMetadata(TestCase):
             version_message=None,
         )
         self.assertEqual(
-            saved_metadata, json.dumps(TEST_DATASET_METADATA, indent=4, sort_keys=True)
+            saved_file_data[0],
+            json.dumps(TEST_DATASET_METADATA, indent=4, sort_keys=True),
         )
-        mock_upload_dataset_metadata_version.assert_not_called()
+        self.mock_upload_dataset_metadata_version.assert_not_called()
 
         self.assertEqual(
             result.output, f"Saved existing dataset metadata to {metadata_save_path}\n"
@@ -1044,21 +1128,13 @@ class TestUploadDatasetMetadata(TestCase):
 
     def test_upload_dataset_metadata_with_metadata_and_all_optional_modifications(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset_metadata_version,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-metadata' command works correctly
         when a path to metadata and a version message is given"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
         metadata_path = "metadata.json"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         options = {
@@ -1086,10 +1162,8 @@ class TestUploadDatasetMetadata(TestCase):
             "version_message": "Some version message",
         }
 
-        args = add_dataset_metadata_common_options(
+        additional_args = add_dataset_metadata_common_options(
             args=[
-                "dataset-metadata",
-                dataset_version_id,
                 "--metadata",
                 metadata_path,
             ],
@@ -1099,30 +1173,25 @@ class TestUploadDatasetMetadata(TestCase):
         )
 
         # CALL
-        with runner.isolated_filesystem():
-            with open(metadata_path, "w", encoding="utf-8") as file:
-                file.write("test metadata file")
-            result = runner.invoke(
-                upload.upload,
-                args,
-                input="y",
-            )
+        result, _ = self.invoke_command(
+            file_paths=[metadata_path], additional_args=additional_args, input="y"
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=Path(metadata_path),
             **options,
         )
-        mock_upload_dataset_metadata_version.assert_called_once_with(
-            session,
+        self.mock_upload_dataset_metadata_version.assert_called_once_with(
+            self.mock_session,
             dataset_id=metadata.dataset_id,
-            version_id=dataset_version_id,
-            metadata=mock_modify_dataset_metadata_for_upload.return_value,
+            version_id=self.dataset_version_id,
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
             json=False,
         )
 
@@ -1138,35 +1207,23 @@ class TestUploadDatasetMetadata(TestCase):
 
     def test_upload_dataset_metadata_skipping_confirmation(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset_metadata_version,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-metadata' command works correctly when
         given a -y flag to skip the confirmation"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         # CALL
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                upload.upload,
-                ["dataset-metadata", dataset_version_id, "-y"],
-            )
+        result, _ = self.invoke_command(additional_args=["-y"])
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -1189,12 +1246,64 @@ class TestUploadDatasetMetadata(TestCase):
             rights=None,
             version_message=None,
         )
-        mock_upload_dataset_metadata_version.assert_called_once_with(
-            session,
+        self.mock_upload_dataset_metadata_version.assert_called_once_with(
+            self.mock_session,
             dataset_id=metadata.dataset_id,
-            version_id=dataset_version_id,
-            metadata=mock_modify_dataset_metadata_for_upload.return_value,
+            version_id=self.dataset_version_id,
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
             json=False,
+        )
+
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_upload_dataset_metadata_json(
+        self,
+    ):
+        """Tests that the 'upload dataset-metadata' command works correctly
+        when given a --json flag"""
+
+        # SETUP
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
+
+        # CALL
+        result, _ = self.invoke_command(additional_args=["--json"])
+
+        # ASSERT
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
+        )
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+            existing_metadata=TEST_DATASET_METADATA,
+            metadata_path=None,
+            title=None,
+            description=None,
+            subject=None,
+            identifiers=None,
+            themes=None,
+            language=None,
+            keywords=None,
+            standard=None,
+            start_date=None,
+            end_date=None,
+            organisation=None,
+            people=None,
+            created_date=None,
+            update_frequency=None,
+            publisher=None,
+            contact=None,
+            license=None,
+            rights=None,
+            version_message=None,
+        )
+        self.mock_upload_dataset_metadata_version.assert_called_once_with(
+            self.mock_session,
+            dataset_id=metadata.dataset_id,
+            version_id=self.dataset_version_id,
+            metadata=self.mock_modify_dataset_metadata_for_upload.return_value,
+            json=True,
         )
 
         self.assertEqual(result.output, "")
@@ -1202,38 +1311,22 @@ class TestUploadDatasetMetadata(TestCase):
 
     def test_upload_metadata_cancel(
         self,
-        mock_modify_dataset_metadata_for_upload,
-        mock_cli_get_latest_dataset_metadata,
-        mock_upload_dataset_metadata_version,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload dataset-metadata' command can be canceled"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        dataset_version_id = "some-existing-version-id"
-        mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
+        self.mock_cli_get_latest_dataset_metadata.return_value = TEST_DATASET_METADATA
         metadata = parse_dataset_metadata(TEST_DATASET_METADATA)
 
         # CALL
-        with runner.isolated_filesystem():
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "dataset-metadata",
-                    dataset_version_id,
-                ],
-                input="n",
-            )
+        result, _ = self.invoke_command(input="n")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, dataset_version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.dataset_version_id
         )
-        mock_modify_dataset_metadata_for_upload.assert_called_once_with(
+        self.mock_modify_dataset_metadata_for_upload.assert_called_once_with(
             existing_metadata=TEST_DATASET_METADATA,
             metadata_path=None,
             title=None,
@@ -1256,7 +1349,7 @@ class TestUploadDatasetMetadata(TestCase):
             rights=None,
             version_message=None,
         )
-        mock_upload_dataset_metadata_version.assert_not_called()
+        self.mock_upload_dataset_metadata_version.assert_not_called()
 
         self.assertEqual(
             result.output,
@@ -1269,50 +1362,79 @@ class TestUploadDatasetMetadata(TestCase):
         self.assertEqual(result.exit_code, 1)
 
 
-@patch("dafni_cli.commands.upload.DAFNISession")
-@patch("dafni_cli.commands.upload.upload_workflow")
 class TestUploadWorkflow(TestCase):
     """Test class to test the upload workflow commands"""
 
-    def test_upload_workflow(
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.definition_path = "test_definition.json"
+        self.version_message = "Initial version"
+
+        self.mock_DAFNISession = patch("dafni_cli.commands.upload.DAFNISession").start()
+        self.mock_session = MagicMock()
+        self.mock_DAFNISession.return_value = self.mock_session
+
+        self.mock_upload_workflow = patch(
+            "dafni_cli.commands.upload.upload_workflow"
+        ).start()
+
+    def invoke_command(
         self,
-        mock_upload_workflow,
-        mock_DAFNISession,
-    ):
-        """Tests that the 'upload workflow' command works correctly when
-        no parent is given"""
+        additional_args: Optional[List[str]] = None,
+        input: Optional[str] = None,
+    ) -> Result:
+        """Invokes the upload dataset command with all required arguments provided
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
+        Args:
+            additional_args (Optional[List[str]]): Any additional parameters to
+                                                     add
+            input (Optional[str]): 'input' to pass to CliRunner's invoke function
+        """
+        if additional_args is None:
+            additional_args = []
+
         runner = CliRunner()
-        version_message = "Initial version"
 
-        # CALL
         with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
+            with open(self.definition_path, "w", encoding="utf-8") as file:
+                file.write("{}")
             result = runner.invoke(
                 upload.upload,
                 [
                     "workflow",
-                    "test_definition.json",
+                    self.definition_path,
                     "--version-message",
-                    version_message,
-                ],
-                input="y",
+                    self.version_message,
+                ]
+                + additional_args,
+                input=input,
             )
+        return result
+
+    def test_upload_workflow(
+        self,
+    ):
+        """Tests that the 'upload workflow' command works correctly when
+        no parent is given"""
+
+        # CALL
+        result = self.invoke_command(input="y")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_workflow.assert_called_once_with(
-            session, Path("test_definition.json"), version_message, None, json=False
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_workflow.assert_called_once_with(
+            self.mock_session,
+            Path(self.definition_path),
+            self.version_message,
+            None,
+            json=False,
         )
 
         self.assertEqual(
             result.output,
-            "Workflow definition file path: test_definition.json\n"
-            f"Version message: {version_message}\n"
+            f"Workflow definition file path: {self.definition_path}\n"
+            f"Version message: {self.version_message}\n"
             "No parent workflow: new workflow to be created\n"
             "Confirm workflow upload? [y/N]: y\n",
         )
@@ -1320,87 +1442,76 @@ class TestUploadWorkflow(TestCase):
 
     def test_upload_workflow_with_parent(
         self,
-        mock_upload_workflow,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload workflow' command works correctly when
         a parent is given"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        version_message = "Initial version"
+        parent_id = "parent-id"
 
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "workflow",
-                    "test_definition.json",
-                    "--version-message",
-                    version_message,
-                    "--parent-id",
-                    "parent-id",
-                ],
-                input="y",
-            )
+        result = self.invoke_command(
+            additional_args=["--parent-id", parent_id], input="y"
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_workflow.assert_called_once_with(
-            session,
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_workflow.assert_called_once_with(
+            self.mock_session,
             Path("test_definition.json"),
-            version_message,
-            "parent-id",
+            self.version_message,
+            parent_id,
             json=False,
         )
 
         self.assertEqual(
             result.output,
-            "Workflow definition file path: test_definition.json\n"
-            f"Version message: {version_message}\n"
-            "Parent workflow ID: parent-id\n"
+            f"Workflow definition file path: {self.definition_path}\n"
+            f"Version message: {self.version_message}\n"
+            f"Parent workflow ID: {parent_id}\n"
             "Confirm workflow upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
     def test_upload_workflow_skipping_confirmation(
         self,
-        mock_upload_workflow,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload workflow' command works correctly when
         given a -y flag to skip the confirmation"""
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        version_message = "Initial version"
-
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "workflow",
-                    "test_definition.json",
-                    "--version-message",
-                    version_message,
-                    "-y",
-                ],
-            )
+        result = self.invoke_command(additional_args=["-y"])
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_workflow.assert_called_once_with(
-            session, Path("test_definition.json"), version_message, None, json=False
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_workflow.assert_called_once_with(
+            self.mock_session,
+            Path(self.definition_path),
+            self.version_message,
+            None,
+            json=False,
+        )
+
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_upload_workflow_json(
+        self,
+    ):
+        """Tests that the 'upload workflow' command works correctly when
+        given a --json flag"""
+
+        # CALL
+        result = self.invoke_command(additional_args=["--json"])
+
+        # ASSERT
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_workflow.assert_called_once_with(
+            self.mock_session,
+            Path(self.definition_path),
+            self.version_message,
+            None,
+            json=True,
         )
 
         self.assertEqual(result.output, "")
@@ -1408,40 +1519,20 @@ class TestUploadWorkflow(TestCase):
 
     def test_upload_workflow_cancel(
         self,
-        mock_upload_workflow,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload workflow' command can be canceled"""
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        version_message = "Initial version"
-
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "workflow",
-                    "test_definition.json",
-                    "--version-message",
-                    version_message,
-                ],
-                input="n",
-            )
+        result = self.invoke_command(input="n")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_workflow.assert_not_called()
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_workflow.assert_not_called()
 
         self.assertEqual(
             result.output,
-            "Workflow definition file path: test_definition.json\n"
-            f"Version message: {version_message}\n"
+            f"Workflow definition file path: {self.definition_path}\n"
+            f"Version message: {self.version_message}\n"
             "No parent workflow: new workflow to be created\n"
             "Confirm workflow upload? [y/N]: n\n"
             "Aborted!\n",
@@ -1449,78 +1540,117 @@ class TestUploadWorkflow(TestCase):
         self.assertEqual(result.exit_code, 1)
 
 
-@patch("dafni_cli.commands.upload.DAFNISession")
-@patch("dafni_cli.commands.upload.upload_parameter_set")
 class TestUploadWorkflowParameterSet(TestCase):
     """Test class to test the upload workflow-parameter-set commands"""
 
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.definition_path = "test_definition.json"
+
+        self.mock_DAFNISession = patch("dafni_cli.commands.upload.DAFNISession").start()
+        self.mock_session = MagicMock()
+        self.mock_DAFNISession.return_value = self.mock_session
+
+        self.mock_upload_parameter_set = patch(
+            "dafni_cli.commands.upload.upload_parameter_set"
+        ).start()
+
+        self.addCleanup(patch.stopall)
+
+    def invoke_command(
+        self,
+        additional_args: Optional[List[str]] = None,
+        input: Optional[str] = None,
+    ) -> Result:
+        """Invokes the upload workflow-parameter-srt command with all required
+        arguments provided
+
+        Args:
+            additional_args (Optional[List[str]]): Any additional parameters to
+                                                   add
+            input (Optional[str]): 'input' to pass to CliRunner's invoke function
+        """
+        if additional_args is None:
+            additional_args = []
+
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            with open(self.definition_path, "w", encoding="utf-8") as file:
+                file.write("{}")
+            result = runner.invoke(
+                upload.upload,
+                [
+                    "workflow-parameter-set",
+                    self.definition_path,
+                ]
+                + additional_args,
+                input=input,
+            )
+        return result
+
     def test_upload_workflow_parameter_set(
         self,
-        mock_upload_parameter_set,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload workflow-parameter-set' command works
         correctly"""
 
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
         parameter_set_id = "parameter-set-id"
-        mock_upload_parameter_set.return_value = {"id": parameter_set_id}
+        self.mock_upload_parameter_set.return_value = {"id": parameter_set_id}
 
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "workflow-parameter-set",
-                    "test_definition.json",
-                ],
-                input="y",
-            )
+        result = self.invoke_command(input="y")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_parameter_set.assert_called_once_with(
-            session, Path("test_definition.json"), json=False
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_parameter_set.assert_called_once_with(
+            self.mock_session, Path(self.definition_path), json=False
         )
 
         self.assertEqual(
             result.output,
-            "Parameter set definition file path: test_definition.json\n"
+            f"Parameter set definition file path: {self.definition_path}\n"
             "Confirm parameter set upload? [y/N]: y\n",
         )
         self.assertEqual(result.exit_code, 0)
 
     def test_upload_workflow_parameter_set_skipping_confirmation(
         self,
-        mock_upload_parameter_set,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload workflow-parameter-set' command works
         correctly when given a -y flag to skip the confirmation"""
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                ["workflow-parameter-set", "test_definition.json", "-y"],
-            )
+        result = self.invoke_command(additional_args=["-y"])
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_parameter_set.assert_called_once_with(
-            session, Path("test_definition.json"), json=False
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_parameter_set.assert_called_once_with(
+            self.mock_session, Path(self.definition_path), json=False
+        )
+
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_upload_workflow_parameter_set_json(
+        self,
+    ):
+        """Tests that the 'upload workflow-parameter-set' command works
+        correctly when given a --json flag"""
+
+        # SETUP
+        parameter_set_id = "parameter-set-id"
+        self.mock_upload_parameter_set.return_value = {"id": parameter_set_id}
+
+        # CALL
+        result = self.invoke_command(additional_args=["--json"])
+
+        # ASSERT
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_parameter_set.assert_called_once_with(
+            self.mock_session, Path(self.definition_path), json=True
         )
 
         self.assertEqual(result.output, "")
@@ -1528,36 +1658,19 @@ class TestUploadWorkflowParameterSet(TestCase):
 
     def test_upload_workflow_parameter_set_cancel(
         self,
-        mock_upload_parameter_set,
-        mock_DAFNISession,
     ):
         """Tests that the 'upload workflow-parameter-set' command can be canceled"""
 
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-
         # CALL
-        with runner.isolated_filesystem():
-            with open("test_definition.json", "w", encoding="utf-8") as file:
-                file.write("test definition file")
-            result = runner.invoke(
-                upload.upload,
-                [
-                    "workflow-parameter-set",
-                    "test_definition.json",
-                ],
-                input="n",
-            )
+        result = self.invoke_command(input="n")
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_upload_parameter_set.assert_not_called()
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_upload_parameter_set.assert_not_called()
 
         self.assertEqual(
             result.output,
-            "Parameter set definition file path: test_definition.json\n"
+            f"Parameter set definition file path: {self.definition_path}\n"
             "Confirm parameter set upload? [y/N]: n\n"
             "Aborted!\n",
         )

--- a/test/commands/test_upload.py
+++ b/test/commands/test_upload.py
@@ -451,7 +451,7 @@ class TestUploadDatasetVersion(TestCase):
     def invoke_command(
         self,
         file_paths: List[str],
-        additional_args: Optional[List[str]] = None,
+        additional_args: List[str],
         input: Optional[str] = None,
         file_paths_to_read: Optional[List[str]] = None,
     ) -> Tuple[Result, List[str]]:
@@ -461,15 +461,11 @@ class TestUploadDatasetVersion(TestCase):
         Args:
             file_paths (Optional[List]): List of file paths of files to create prior
                                          to invoking the command
-            additional_args (Optional[List[str]]): Any additional parameters to
-                                                     add
+            additional_args (List[str]): Any additional parameters to add
             input (Optional[str]): 'input' to pass to CliRunner's invoke function
             file_paths_to_read (Optional[List[str]]): Paths to files to read (will
                                                     return the contents in a list)
         """
-        if additional_args is None:
-            additional_args = []
-
         runner = CliRunner()
 
         saved_file_data = []

--- a/test/datasets/test_dataset_upload.py
+++ b/test/datasets/test_dataset_upload.py
@@ -337,7 +337,7 @@ class TestDatasetUpload(TestCase):
 
     def test_upload_files_json(self):
         """Tests that upload_files works as expected with json = True"""
-        self._test_upload_files(False)
+        self._test_upload_files(True)
 
     def _test_commit_metadata(self, json: bool):
         """Tests that _commit_metadata works as expected without a dataset_id

--- a/test/datasets/test_dataset_upload.py
+++ b/test/datasets/test_dataset_upload.py
@@ -264,19 +264,43 @@ class TestModifyDatasetMetadataForUpload(TestCase):
         )
 
 
-@patch("dafni_cli.datasets.dataset_upload.click")
 class TestDatasetUpload(TestCase):
     """Test class to test the functions in dataset_upload.py"""
 
-    @patch("dafni_cli.datasets.dataset_upload.get_data_upload_urls")
-    @patch("dafni_cli.datasets.dataset_upload.upload_file_to_minio")
-    def test_upload_files(
-        self,
-        mock_upload_file_to_minio,
-        mock_get_data_upload_urls,
-        mock_click,
-    ):
-        """Tests that upload_files works as expected"""
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.mock_upload_dataset_metadata = patch(
+            "dafni_cli.api.datasets_api.upload_dataset_metadata"
+        ).start()
+        self.mock_upload_file_to_minio = patch(
+            "dafni_cli.datasets.dataset_upload.upload_file_to_minio"
+        ).start()
+        self.mock_get_data_upload_urls = patch(
+            "dafni_cli.datasets.dataset_upload.get_data_upload_urls"
+        ).start()
+        self.mock_create_temp_bucket = patch(
+            "dafni_cli.datasets.dataset_upload.create_temp_bucket"
+        ).start()
+        self.mock_delete_temp_bucket = patch(
+            "dafni_cli.datasets.dataset_upload.delete_temp_bucket"
+        ).start()
+        self.mock_upload_dataset_metadata_version = patch(
+            "dafni_cli.datasets.dataset_upload.datasets_api.upload_dataset_metadata_version"
+        ).start()
+        self.mock_print_json = patch(
+            "dafni_cli.datasets.dataset_upload.print_json"
+        ).start()
+        self.mock_optional_echo = patch(
+            "dafni_cli.datasets.dataset_upload.optional_echo"
+        ).start()
+        self.mock_click = patch("dafni_cli.datasets.dataset_upload.click").start()
+
+        self.addCleanup(patch.stopall)
+
+    def _test_upload_files(self, json: bool):
+        """Tests that upload_files works as expected with a given value of
+        json"""
         # SETUP
         session = MagicMock()
         temp_bucket_id = "some-temp-bucket"
@@ -286,60 +310,69 @@ class TestDatasetUpload(TestCase):
             "urls": {file_paths[idx].name: url for idx, url in enumerate(urls)}
         }
 
-        mock_get_data_upload_urls.return_value = upload_urls
+        self.mock_get_data_upload_urls.return_value = upload_urls
 
         # CALL
-        dataset_upload.upload_files(session, temp_bucket_id, file_paths)
+        dataset_upload.upload_files(session, temp_bucket_id, file_paths, json=json)
 
         # ASSERT
-        mock_get_data_upload_urls.assert_called_once_with(
+        self.mock_get_data_upload_urls.assert_called_once_with(
             session, temp_bucket_id, [file_path.name for file_path in file_paths]
         )
-        mock_upload_file_to_minio.assert_has_calls(
+        self.mock_upload_file_to_minio.assert_has_calls(
             [call(session, url, file_paths[idx]) for idx, url in enumerate(urls)]
         )
 
-        mock_click.echo.assert_has_calls(
+        self.assertEqual(
+            self.mock_optional_echo.call_args_list,
             [
-                call("Retrieving file upload URls"),
-                call("Uploading files"),
-            ]
+                call("Retrieving file upload URls", json),
+                call("Uploading files", json),
+            ],
         )
 
-    @patch("dafni_cli.api.datasets_api.upload_dataset_metadata")
-    def test_commit_metadata(
-        self,
-        mock_upload_dataset_metadata,
-        mock_click,
-    ):
-        """Tests that _commit_metadata works as expected without a dataset_id"""
+    def test_upload_files(self):
+        """Tests that upload_files works as expected with json = False"""
+        self._test_upload_files(False)
+
+    def test_upload_files_json(self):
+        """Tests that upload_files works as expected with json = True"""
+        self._test_upload_files(False)
+
+    def _test_commit_metadata(self, json: bool):
+        """Tests that _commit_metadata works as expected without a dataset_id
+        and a given value of json"""
         # SETUP
         session = MagicMock()
         metadata = MOCK_DEFINITION_DATA
         temp_bucket_id = "some-temp-bucket"
 
         # CALL
-        result = dataset_upload._commit_metadata(session, metadata, temp_bucket_id)
+        result = dataset_upload._commit_metadata(
+            session, metadata, temp_bucket_id, json=json
+        )
 
         # ASSERT
-        mock_upload_dataset_metadata.assert_called_with(
+        self.mock_upload_dataset_metadata.assert_called_with(
             session, temp_bucket_id, metadata, dataset_id=None
         )
 
-        mock_click.echo.assert_has_calls(
-            [
-                call("Uploading metadata file"),
-            ]
-        )
-        self.assertEqual(result, mock_upload_dataset_metadata.return_value)
+        self.mock_optional_echo.assert_called_once_with("Uploading metadata file", json)
+        self.assertEqual(result, self.mock_upload_dataset_metadata.return_value)
 
-    @patch("dafni_cli.api.datasets_api.upload_dataset_metadata")
-    def test_commit_metadata_with_dataset_id(
-        self,
-        mock_upload_dataset_metadata,
-        mock_click,
-    ):
-        """Tests that _commit_metadata works as expected with a dataset_id"""
+    def test_commit_metadata(self):
+        """Tests that _commit_metadata works as expected without a dataset_id
+        and json = False"""
+        self._test_commit_metadata(False)
+
+    def test_commit_metadata_json(self):
+        """Tests that _commit_metadata works as expected without a dataset_id
+        and json = True"""
+        self._test_commit_metadata(True)
+
+    def _test_commit_metadata_with_dataset_id(self, json: bool):
+        """Tests that _commit_metadata works as expected with a dataset_id and
+        a given value of json"""
         # SETUP
         session = MagicMock()
         metadata = MOCK_DEFINITION_DATA
@@ -348,199 +381,231 @@ class TestDatasetUpload(TestCase):
 
         # CALL
         result = dataset_upload._commit_metadata(
-            session, metadata, temp_bucket_id, dataset_id=dataset_id
+            session, metadata, temp_bucket_id, dataset_id=dataset_id, json=json
         )
 
         # ASSERT
-        mock_upload_dataset_metadata.assert_called_with(
-            session, temp_bucket_id, metadata, dataset_id=dataset_id
+        self.mock_upload_dataset_metadata.assert_called_with(
+            session,
+            temp_bucket_id,
+            metadata,
+            dataset_id=dataset_id,
         )
 
-        mock_click.echo.assert_has_calls(
-            [
-                call("Uploading metadata file"),
-            ]
-        )
-        self.assertEqual(result, mock_upload_dataset_metadata.return_value)
+        self.mock_optional_echo.assert_called_once_with("Uploading metadata file", json)
+        self.assertEqual(result, self.mock_upload_dataset_metadata.return_value)
 
-    @patch("dafni_cli.api.datasets_api.upload_dataset_metadata")
-    def test_commit_metadata_exits_on_error(
-        self,
-        mock_upload_dataset_metadata,
-        mock_click,
-    ):
-        """Tests that _commit_metadata calls SystemExit(1) when an error occurs"""
+    def test_commit_metadata_with_dataset_id(self):
+        """Tests that _commit_metadata works as expected with a dataset_id with
+        json = False"""
+        self._test_commit_metadata_with_dataset_id(False)
+
+    def test_commit_metadata_with_dataset_id_json(self):
+        """Tests that _commit_metadata works as expected with a dataset_id with
+        json = True"""
+        self._test_commit_metadata_with_dataset_id(True)
+
+    def _test_commit_metadata_exits_on_error(self, json: bool):
+        """Tests that _commit_metadata calls SystemExit(1) when an error occurs
+        and using a given value of json"""
         # SETUP
         session = MagicMock()
         metadata = MOCK_DEFINITION_DATA
         temp_bucket_id = "some-temp-bucket"
 
         error = DAFNIError("Some error message")
-        mock_upload_dataset_metadata.side_effect = error
+        self.mock_upload_dataset_metadata.side_effect = error
 
         # CALL
         with self.assertRaises(SystemExit):
-            dataset_upload._commit_metadata(session, metadata, temp_bucket_id)
+            dataset_upload._commit_metadata(
+                session, metadata, temp_bucket_id, json=json
+            )
 
         # ASSERT
-        mock_click.echo.assert_has_calls(
-            [
-                call("Uploading metadata file"),
-                call(f"\nMetadata upload failed: {error}"),
-            ]
+        self.mock_optional_echo.assert_called_once_with("Uploading metadata file", json)
+        self.mock_click.echo.assert_called_once_with(
+            f"\nMetadata upload failed: {error}"
         )
 
-    @patch("dafni_cli.datasets.dataset_upload.upload_files")
-    @patch("dafni_cli.datasets.dataset_upload._commit_metadata")
-    @patch("dafni_cli.datasets.dataset_upload.create_temp_bucket")
-    def test_upload_dataset(
-        self,
-        mock_create_temp_bucket,
-        mock_commit_metadata,
-        mock_upload_files,
-        mock_click,
-    ):
-        """Tests that upload_dataset works as expected"""
-        # SETUP
-        session = MagicMock()
-        metadata = MagicMock()
-        file_paths = ["file_1.txt", "file_2.txt"]
-        temp_bucket_id = "some-temp-bucket"
-        dataset_id = MagicMock()
-        details = {
-            "datasetId": "dataset-id",
-            "versionId": "version-id",
-            "metadataId": "metadata-id",
-        }
+    def test_commit_metadata_exits_on_error(self):
+        """Tests that _commit_metadata calls SystemExit(1) when an error occurs
+        and json = False"""
+        self._test_commit_metadata_exits_on_error(False)
 
-        mock_create_temp_bucket.return_value = temp_bucket_id
-        mock_commit_metadata.return_value = details
+    def test_commit_metadata_exits_on_error_json(self):
+        """Tests that _commit_metadata calls SystemExit(1) when an error occurs
+        and json = True"""
+        self._test_commit_metadata_exits_on_error(True)
 
-        # CALL
-        dataset_upload.upload_dataset(session, metadata, file_paths, dataset_id)
+    def _test_upload_dataset(self, json: bool):
+        """Tests that upload_dataset works as expected with the given value
+        of json"""
 
-        # ASSERT
-        mock_create_temp_bucket.assert_called_once_with(session)
-        mock_upload_files.assert_called_once_with(
-            session,
-            temp_bucket_id,
-            file_paths,
-        )
-        mock_commit_metadata.assert_called_once_with(
-            session, metadata, temp_bucket_id, dataset_id=dataset_id
-        )
+        # Additionally patch these functions in the same file
+        with patch(
+            "dafni_cli.datasets.dataset_upload._commit_metadata"
+        ) as mock_commit_metadata, patch(
+            "dafni_cli.datasets.dataset_upload.upload_files"
+        ) as mock_upload_files:
+            # SETUP
+            session = MagicMock()
+            metadata = MagicMock()
+            file_paths = ["file_1.txt", "file_2.txt"]
+            temp_bucket_id = "some-temp-bucket"
+            dataset_id = MagicMock()
+            details = {
+                "datasetId": "dataset-id",
+                "versionId": "version-id",
+                "metadataId": "metadata-id",
+            }
 
-        mock_click.echo.assert_has_calls(
-            [
-                call("\nRetrieving temporary bucket ID"),
-                call("\nUpload successful"),
-                call(f"Dataset ID: {details['datasetId']}"),
-                call(f"Version ID: {details['versionId']}"),
-                call(f"Metadata ID: {details['metadataId']}"),
-            ]
-        )
+            self.mock_create_temp_bucket.return_value = temp_bucket_id
+            mock_commit_metadata.return_value = details
 
-    @patch("dafni_cli.datasets.dataset_upload.upload_files")
-    @patch("dafni_cli.datasets.dataset_upload._commit_metadata")
-    @patch("dafni_cli.datasets.dataset_upload.create_temp_bucket")
-    @patch("dafni_cli.datasets.dataset_upload.delete_temp_bucket")
-    def test_upload_dataset_deletes_bucket_on_error(
-        self,
-        mock_delete_temp_bucket,
-        mock_create_temp_bucket,
-        mock_commit_metadata,
-        mock_upload_files,
-        mock_click,
-    ):
+            # CALL
+            dataset_upload.upload_dataset(
+                session, metadata, file_paths, dataset_id, json=json
+            )
+
+            # ASSERT
+            self.mock_create_temp_bucket.assert_called_once_with(session)
+            mock_upload_files.assert_called_once_with(
+                session, temp_bucket_id, file_paths, json=json
+            )
+            mock_commit_metadata.assert_called_once_with(
+                session, metadata, temp_bucket_id, dataset_id=dataset_id, json=json
+            )
+
+            self.mock_optional_echo.assert_called_once_with(
+                "\nRetrieving temporary bucket ID", json
+            )
+
+            if json:
+                self.mock_print_json.assert_called_once_with(details)
+                self.mock_click.echo.assert_not_called()
+            else:
+                self.mock_print_json.assert_not_called()
+                self.mock_click.echo.assert_has_calls(
+                    [
+                        call("\nUpload successful"),
+                        call(f"Dataset ID: {details['datasetId']}"),
+                        call(f"Version ID: {details['versionId']}"),
+                        call(f"Metadata ID: {details['metadataId']}"),
+                    ]
+                )
+
+    def test_upload_dataset(self):
+        """Tests that upload_dataset works as expected with json = False"""
+        self._test_upload_dataset(False)
+
+    def test_upload_dataset_json(self):
+        """Tests that upload_dataset works as expected with json = True"""
+        self._test_upload_dataset(True)
+
+    def _test_upload_dataset_deletes_bucket_on_error(self, json: bool):
         """Tests that upload_dataset deletes the temporary bucket when an
-        error occurs"""
-        # SETUP
-        session = MagicMock()
-        metadata = MagicMock()
-        file_paths = ["file_1.txt", "file_2.txt"]
-        temp_bucket_id = "some-temp-bucket"
+        error occurs while using a specific value of json"""
 
-        mock_create_temp_bucket.return_value = temp_bucket_id
-        mock_commit_metadata.side_effect = HTTPError(400)
+        # Additionally patch these functions in the same file
+        with patch(
+            "dafni_cli.datasets.dataset_upload._commit_metadata"
+        ) as mock_commit_metadata, patch(
+            "dafni_cli.datasets.dataset_upload.upload_files"
+        ) as mock_upload_files:
+            # SETUP
+            session = MagicMock()
+            metadata = MagicMock()
+            file_paths = ["file_1.txt", "file_2.txt"]
+            temp_bucket_id = "some-temp-bucket"
 
-        # CALL
-        with self.assertRaises(HTTPError):
-            dataset_upload.upload_dataset(session, metadata, file_paths)
+            self.mock_create_temp_bucket.return_value = temp_bucket_id
+            mock_commit_metadata.side_effect = HTTPError(400)
 
-        # ASSERT
-        mock_create_temp_bucket.assert_called_once_with(session)
-        mock_upload_files.assert_called_once_with(
-            session,
-            temp_bucket_id,
-            file_paths,
-        )
-        mock_commit_metadata.assert_called_once_with(
-            session, metadata, temp_bucket_id, dataset_id=None
-        )
-        mock_delete_temp_bucket.assert_called_once_with(session, temp_bucket_id)
+            # CALL
+            with self.assertRaises(HTTPError):
+                dataset_upload.upload_dataset(session, metadata, file_paths, json=json)
 
-        mock_click.echo.assert_has_calls(
-            [
-                call("\nRetrieving temporary bucket ID"),
-                call("Deleting temporary bucket"),
-            ]
-        )
+            # ASSERT
+            self.mock_create_temp_bucket.assert_called_once_with(session)
+            mock_upload_files.assert_called_once_with(
+                session, temp_bucket_id, file_paths, json=json
+            )
+            mock_commit_metadata.assert_called_once_with(
+                session, metadata, temp_bucket_id, dataset_id=None, json=json
+            )
+            self.mock_delete_temp_bucket.assert_called_once_with(
+                session, temp_bucket_id
+            )
 
-    @patch("dafni_cli.datasets.dataset_upload.upload_files")
-    @patch("dafni_cli.datasets.dataset_upload._commit_metadata")
-    @patch("dafni_cli.datasets.dataset_upload.create_temp_bucket")
-    @patch("dafni_cli.datasets.dataset_upload.delete_temp_bucket")
+            self.assertEqual(
+                self.mock_optional_echo.call_args_list,
+                [
+                    call("\nRetrieving temporary bucket ID", json),
+                    call("Deleting temporary bucket", json),
+                ],
+            )
+
+    def test_upload_dataset_deletes_bucket_on_error(self):
+        """Tests that upload_dataset deletes the temporary bucket when an
+        error occurs and json = False"""
+        self._test_upload_dataset_deletes_bucket_on_error(False)
+
+    def test_upload_dataset_deletes_bucket_on_error_json(self):
+        """Tests that upload_dataset deletes the temporary bucket when an
+        error occurs and json = True"""
+        self._test_upload_dataset_deletes_bucket_on_error(True)
+
     def test_upload_dataset_deletes_bucket_on_system_exit(
         self,
-        mock_delete_temp_bucket,
-        mock_create_temp_bucket,
-        mock_commit_metadata,
-        mock_upload_files,
-        mock_click,
     ):
         """Tests that upload_dataset deletes the temporary bucket when a
-        SystemExit is triggered"""
-        # SETUP
-        session = MagicMock()
-        metadata = MagicMock()
-        file_paths = ["file_1.txt", "file_2.txt"]
-        temp_bucket_id = "some-temp-bucket"
+        SystemExit is triggered (json is ignored as uses same code as above
+        to do the check anyway)"""
 
-        mock_create_temp_bucket.return_value = temp_bucket_id
-        mock_commit_metadata.side_effect = SystemExit(1)
+        # Additionally patch these functions in the same file
+        with patch(
+            "dafni_cli.datasets.dataset_upload._commit_metadata"
+        ) as mock_commit_metadata, patch(
+            "dafni_cli.datasets.dataset_upload.upload_files"
+        ) as mock_upload_files:
+            # SETUP
+            session = MagicMock()
+            metadata = MagicMock()
+            file_paths = ["file_1.txt", "file_2.txt"]
+            temp_bucket_id = "some-temp-bucket"
 
-        # CALL
-        with self.assertRaises(SystemExit):
-            dataset_upload.upload_dataset(session, metadata, file_paths)
+            self.mock_create_temp_bucket.return_value = temp_bucket_id
+            mock_commit_metadata.side_effect = SystemExit(1)
 
-        # ASSERT
-        mock_create_temp_bucket.assert_called_once_with(session)
-        mock_upload_files.assert_called_once_with(
-            session,
-            temp_bucket_id,
-            file_paths,
-        )
-        mock_commit_metadata.assert_called_once_with(
-            session, metadata, temp_bucket_id, dataset_id=None
-        )
-        mock_delete_temp_bucket.assert_called_once_with(session, temp_bucket_id)
+            # CALL
+            with self.assertRaises(SystemExit):
+                dataset_upload.upload_dataset(session, metadata, file_paths)
 
-        mock_click.echo.assert_has_calls(
-            [
-                call("\nRetrieving temporary bucket ID"),
-                call("Deleting temporary bucket"),
-            ]
-        )
+            # ASSERT
+            self.mock_create_temp_bucket.assert_called_once_with(session)
+            mock_upload_files.assert_called_once_with(
+                session, temp_bucket_id, file_paths, json=False
+            )
+            mock_commit_metadata.assert_called_once_with(
+                session, metadata, temp_bucket_id, dataset_id=None, json=False
+            )
+            self.mock_delete_temp_bucket.assert_called_once_with(
+                session, temp_bucket_id
+            )
 
-    @patch(
-        "dafni_cli.datasets.dataset_upload.datasets_api.upload_dataset_metadata_version"
-    )
-    def test_upload_dataset_metadata_version(
-        self,
-        mock_upload_dataset_metadata,
-        mock_click,
-    ):
-        """Tests that upload_dataset_metadata_version works as expected"""
+            self.assertEqual(
+                self.mock_optional_echo.call_args_list,
+                [
+                    call("\nRetrieving temporary bucket ID", False),
+                    call("Deleting temporary bucket", False),
+                ],
+            )
+
+    def _test_upload_dataset_metadata_version(self, json: bool):
+        """Tests that upload_dataset_metadata_version works as expected with
+        the given value of json"""
+
         # SETUP
         session = MagicMock()
         dataset_id = MagicMock()
@@ -552,23 +617,38 @@ class TestDatasetUpload(TestCase):
             "metadataId": "metadata-id",
         }
 
-        mock_upload_dataset_metadata.return_value = details
+        self.mock_upload_dataset_metadata_version.return_value = details
 
         # CALL
         dataset_upload.upload_dataset_metadata_version(
-            session, dataset_id, version_id, metadata
+            session, dataset_id, version_id, metadata, json=json
         )
 
         # ASSERT
-        mock_upload_dataset_metadata.assert_called_once_with(
+        self.mock_upload_dataset_metadata_version.assert_called_once_with(
             session, dataset_id=dataset_id, version_id=version_id, metadata=metadata
         )
 
-        mock_click.echo.assert_has_calls(
-            [
-                call("\nUpload successful"),
-                call(f"Dataset ID: {details['datasetId']}"),
-                call(f"Version ID: {details['versionId']}"),
-                call(f"Metadata ID: {details['metadataId']}"),
-            ]
-        )
+        if json:
+            self.mock_print_json.assert_called_once_with(details)
+            self.mock_click.echo.assert_not_called()
+        else:
+            self.mock_print_json.assert_not_called()
+            self.mock_click.echo.assert_has_calls(
+                [
+                    call("\nUpload successful"),
+                    call(f"Dataset ID: {details['datasetId']}"),
+                    call(f"Version ID: {details['versionId']}"),
+                    call(f"Metadata ID: {details['metadataId']}"),
+                ]
+            )
+
+    def test_upload_dataset_metadata_version(self):
+        """Tests that upload_dataset_metadata_version works as expected when
+        json = False"""
+        self._test_upload_dataset_metadata_version(False)
+
+    def test_upload_dataset_metadata_version_json(self):
+        """Tests that upload_dataset_metadata_version works as expected when
+        json = True"""
+        self._test_upload_dataset_metadata_version(True)

--- a/test/models/test_upload.py
+++ b/test/models/test_upload.py
@@ -8,23 +8,32 @@ from dafni_cli.models import upload
 from test.api.test_models_api import TEST_MODELS_UPLOAD_RESPONSE
 
 
-@patch("dafni_cli.models.upload.click")
-@patch("dafni_cli.models.upload.validate_model_definition")
-@patch("dafni_cli.models.upload.get_model_upload_urls")
-@patch("dafni_cli.models.upload.upload_file_to_minio")
-@patch("dafni_cli.models.upload.model_version_ingest")
 class TestModelUpload(TestCase):
     """Test class to test the functions in model/upload.py"""
 
-    def test_model_upload(
-        self,
-        mock_model_version_ingest,
-        mock_upload_file_to_minio,
-        mock_get_model_upload_urls,
-        mock_validate_model_definition,
-        mock_click,
-    ):
-        """Tests that upload_model works as expected"""
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.mock_model_version_ingest = patch(
+            "dafni_cli.models.upload.model_version_ingest"
+        ).start()
+        self.mock_upload_file_to_minio = patch(
+            "dafni_cli.models.upload.upload_file_to_minio"
+        ).start()
+        self.mock_get_model_upload_urls = patch(
+            "dafni_cli.models.upload.get_model_upload_urls"
+        ).start()
+        self.mock_validate_model_definition = patch(
+            "dafni_cli.models.upload.validate_model_definition"
+        ).start()
+        self.mock_print_json = patch("dafni_cli.models.upload.print_json").start()
+        self.mock_optional_echo = patch("dafni_cli.models.upload.optional_echo").start()
+        self.mock_click = patch("dafni_cli.models.upload.click").start()
+
+        self.addCleanup(patch.stopall)
+
+    def _test_model_upload(self, json: bool):
+        """Tests that upload_model works as expected with a given json value as input"""
         # SETUP
         session = MagicMock()
         definition_path = Path("path/to/definition")
@@ -36,21 +45,24 @@ class TestModelUpload(TestCase):
             "success": True,
             "version_id": "0a0a0a0a-0a00-0a00-a000-0a0a0000000a",
         }
-        mock_model_version_ingest.return_value = details
-        mock_get_model_upload_urls.return_value = (
+        self.mock_model_version_ingest.return_value = details
+        self.mock_get_model_upload_urls.return_value = (
             TEST_MODELS_UPLOAD_RESPONSE["id"],
             TEST_MODELS_UPLOAD_RESPONSE["urls"],
         )
 
         # CALL
         upload.upload_model(
-            session, definition_path, image_path, version_message, parent_id
+            session, definition_path, image_path, version_message, parent_id, json=json
         )
 
         # ASSERT
-        mock_validate_model_definition.assert_called_once_with(session, definition_path)
-        mock_get_model_upload_urls.assert_called_once_with(session)
-        mock_upload_file_to_minio.assert_has_calls(
+        self.mock_validate_model_definition.assert_called_once_with(
+            session, definition_path
+        )
+        self.mock_get_model_upload_urls.assert_called_once_with(session)
+        self.assertEqual(
+            self.mock_upload_file_to_minio.call_args_list,
             [
                 call(
                     session,
@@ -62,60 +74,93 @@ class TestModelUpload(TestCase):
                     TEST_MODELS_UPLOAD_RESPONSE["urls"]["image"],
                     image_path,
                 ),
-            ]
+            ],
         )
-        mock_model_version_ingest.assert_called_once_with(
+        self.mock_model_version_ingest.assert_called_once_with(
             session, TEST_MODELS_UPLOAD_RESPONSE["id"], "version_message", parent_id
         )
 
-        mock_click.echo.assert_has_calls(
+        self.assertEqual(
+            self.mock_optional_echo.call_args_list,
             [
-                call("Validating model definition"),
-                call("Getting urls"),
-                call("Uploading model definition and image"),
-                call("Ingesting model"),
-                call("\nUpload successful"),
-                call(f"Version ID: {details['version_id']}"),
-            ]
+                call("Validating model definition", json),
+                call("Getting urls", json),
+                call("Uploading model definition and image", json),
+                call("Ingesting model", json),
+            ],
         )
 
-    def test_model_upload_exits_for_validation_error(
-        self,
-        mock_model_version_ingest,
-        mock_upload_file_to_minio,
-        mock_get_model_upload_urls,
-        mock_validate_model_definition,
-        mock_click,
-    ):
-        """Tests that upload_dataset works as expected without"""
+        if json:
+            self.mock_print_json.assert_called_once_with(details)
+        else:
+            self.assertEqual(
+                self.mock_click.echo.call_args_list,
+                [
+                    call("\nUpload successful"),
+                    call(f"Version ID: {details['version_id']}"),
+                ],
+            )
+
+    def test_model_upload(self):
+        """Tests that upload_model works as expected with json = False"""
+        self._test_model_upload(json=False)
+
+    def test_model_upload_json(self):
+        """Tests that upload_model works as expected with json = True"""
+        self._test_model_upload(json=True)
+
+    def _test_model_upload_exits_for_validation_error(self, json: bool):
+        """Tests that upload_dataset works as expected when there is a
+        validation error with the given value of json"""
+
         # SETUP
         session = MagicMock()
         definition_path = Path("path/to/definition")
         image_path = Path("path/to/image")
         version_message = "version_message"
         parent_id = MagicMock()
-        mock_get_model_upload_urls.return_value = (
+        self.mock_get_model_upload_urls.return_value = (
             TEST_MODELS_UPLOAD_RESPONSE["id"],
             TEST_MODELS_UPLOAD_RESPONSE["urls"],
         )
-        mock_validate_model_definition.side_effect = ValidationError(
+        self.mock_validate_model_definition.side_effect = ValidationError(
             "Some validation error message"
         )
 
         # CALL & ASSERT
         with self.assertRaises(SystemExit):
             upload.upload_model(
-                session, definition_path, image_path, version_message, parent_id
+                session,
+                definition_path,
+                image_path,
+                version_message,
+                parent_id,
+                json=json,
             )
 
-        mock_validate_model_definition.assert_called_once_with(session, definition_path)
-        mock_get_model_upload_urls.assert_not_called()
-        mock_upload_file_to_minio.assert_not_called()
-        mock_model_version_ingest.assert_not_called()
-
-        mock_click.echo.assert_has_calls(
-            [
-                call("Validating model definition"),
-                call(mock_validate_model_definition.side_effect),
-            ]
+        self.mock_validate_model_definition.assert_called_once_with(
+            session, definition_path
         )
+        self.mock_get_model_upload_urls.assert_not_called()
+        self.mock_upload_file_to_minio.assert_not_called()
+        self.mock_model_version_ingest.assert_not_called()
+
+        self.mock_optional_echo.assert_called_once_with(
+            "Validating model definition", json
+        )
+
+        self.mock_click.echo.assert_called_once_with(
+            self.mock_validate_model_definition.side_effect
+        )
+
+    def test_model_upload_exits_for_validation_error(self):
+        """Tests that upload_dataset works as expected when there is a
+        validation error with json = False"""
+
+        self._test_model_upload_exits_for_validation_error(json=False)
+
+    def test_model_upload_exits_for_validation_error_json(self):
+        """Tests that upload_dataset works as expected when there is a
+        validation error with json = True"""
+
+        self._test_model_upload_exits_for_validation_error(json=True)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -201,8 +201,8 @@ class TestArgumentConfirmation(TestCase):
         )
         mock_click.confirm.assert_called_once_with(confirmation_message, abort=True)
 
-    def test_nothing_happens_when_yes_is_true(self, mock_click):
-        """Tests that nothing is done when 'yes' is True"""
+    def test_nothing_happens_when_skip_is_true(self, mock_click):
+        """Tests that nothing is done when 'skip' is True"""
         # CALL
         utils.argument_confirmation(
             [
@@ -212,7 +212,7 @@ class TestArgumentConfirmation(TestCase):
             ],
             "confirmation message",
             ["additional message 1", "additional message 2"],
-            yes=True,
+            skip=True,
         )
 
         # ASSERT

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import List, Optional
 from unittest import TestCase
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 from zipfile import ZipFile
 
 from dafni_cli import utils
@@ -544,3 +544,30 @@ class TestConstructValidationErrorsFromDict(TestCase):
                 "Error: ( more_errors -> hello ) - world",
             ],
         )
+
+
+@patch("dafni_cli.utils.click")
+class TestOptionalEcho(TestCase):
+    """Test class to test the optional_echo function"""
+
+    def test_outputs_when_passed_false(self, mock_click):
+        """Tests optional_echo calls click.echo when passed a value of False"""
+        # SETUP
+        message = MagicMock()
+
+        # CALL
+        utils.optional_echo(message, False)
+
+        # ASSERT
+        mock_click.echo.assert_called_once_with(message)
+
+    def test_does_not_output_when_passed_true(self, mock_click):
+        """Tests optional_echo calls click.echo when passed a value of True"""
+        # SETUP
+        message = MagicMock()
+
+        # CALL
+        utils.optional_echo(message, True)
+
+        # ASSERT
+        mock_click.echo.assert_not_called()

--- a/test/workflows/test_upload.py
+++ b/test/workflows/test_upload.py
@@ -1,0 +1,175 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import MagicMock, call, patch
+
+from dafni_cli.api.exceptions import ValidationError
+from dafni_cli.workflows import upload
+
+from test.fixtures.workflow_parameter_set import TEST_WORKFLOW_PARAMETER_SET
+from test.fixtures.workflows import TEST_WORKFLOW
+
+
+class TestWorkflowUpload(TestCase):
+    """Test class to test the upload_workflow function"""
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.mock_workflows_api = patch(
+            "dafni_cli.workflows.upload.workflows_api"
+        ).start()
+        self.mock_print_json = patch("dafni_cli.workflows.upload.print_json").start()
+        self.mock_optional_echo = patch(
+            "dafni_cli.workflows.upload.optional_echo"
+        ).start()
+        self.mock_click = patch("dafni_cli.workflows.upload.click").start()
+
+        self.addCleanup(patch.stopall)
+
+    def _test_upload_workflow(self, json: bool):
+        """Tests that upload_workflow works as expected with a given json
+        value"""
+        # SETUP
+        session = MagicMock()
+        definition_path = Path("path/to/definition")
+        version_message = MagicMock()
+        parent_id = MagicMock()
+        details = TEST_WORKFLOW
+
+        self.mock_workflows_api.upload_workflow.return_value = details
+
+        # CALL
+        upload.upload_workflow(
+            session, definition_path, version_message, parent_id, json=json
+        )
+
+        # ASSERT
+        self.mock_optional_echo.assert_called_with("Uploading workflow", json)
+        self.mock_workflows_api.upload_workflow.assert_called_once_with(
+            session, definition_path, version_message, parent_id
+        )
+
+        if json:
+            self.mock_print_json.assert_called_once_with(details)
+            self.mock_click.echo.assert_not_called()
+        else:
+            self.mock_print_json.assert_not_called()
+            self.assertEqual(
+                self.mock_click.echo.call_args_list,
+                [call("\nUpload successful"), call(f"Version ID: {details['id']}")],
+            )
+
+    def test_upload_workflow(self):
+        """Tests that upload_workflow works as expected when json = False"""
+        self._test_upload_workflow(json=False)
+
+    def test_upload_workflow_json(self):
+        """Tests that upload_workflow works as expected when json = True"""
+        self._test_upload_workflow(json=True)
+
+
+class TestParameterSetUpload(TestCase):
+    """Test class to test the upload_parameter_set function"""
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.mock_workflows_api = patch(
+            "dafni_cli.workflows.upload.workflows_api"
+        ).start()
+        self.mock_print_json = patch("dafni_cli.workflows.upload.print_json").start()
+        self.mock_optional_echo = patch(
+            "dafni_cli.workflows.upload.optional_echo"
+        ).start()
+        self.mock_click = patch("dafni_cli.workflows.upload.click").start()
+
+        self.addCleanup(patch.stopall)
+
+    def _test_upload_parameter_set(self, json: bool):
+        """Tests that upload_parameter_set works as expected with a given value
+        of json"""
+        # SETUP
+        session = MagicMock()
+        definition_path = Path("path/to/definition")
+        details = TEST_WORKFLOW_PARAMETER_SET
+
+        self.mock_workflows_api.upload_parameter_set.return_value = details
+
+        # CALL
+        upload.upload_parameter_set(session, definition_path, json=json)
+
+        # ASSERT
+        self.mock_workflows_api.validate_parameter_set_definition.assert_called_once_with(
+            session, definition_path
+        )
+        self.assertEqual(
+            self.mock_optional_echo.call_args_list,
+            [
+                call("Validating parameter set definition", json),
+                call("Uploading parameter set", json),
+            ],
+        )
+        self.mock_workflows_api.upload_parameter_set.assert_called_once_with(
+            session, definition_path
+        )
+
+        if json:
+            self.mock_print_json.assert_called_once_with(details)
+            self.mock_click.echo.assert_not_called()
+        else:
+            self.mock_print_json.assert_not_called()
+            self.assertEqual(
+                self.mock_click.echo.call_args_list,
+                [
+                    call("\nUpload successful"),
+                    call(f"Parameter set ID: {details['id']}"),
+                ],
+            )
+
+    def test_upload_parameter_set(self):
+        """Tests that upload_parameter_set works as expected with json = False"""
+        self._test_upload_parameter_set(json=False)
+
+    def test_upload_parameter_set_json(self):
+        """Tests that upload_parameter_set works as expected with json = True"""
+        self._test_upload_parameter_set(json=True)
+
+    def _test_upload_parameter_set_exits_for_validation_error(self, json: bool):
+        """Tests that upload_parameter_set works as expected when there is a
+        validation error with a given value of json"""
+        # SETUP
+        session = MagicMock()
+        definition_path = Path("path/to/definition")
+
+        self.mock_workflows_api.validate_parameter_set_definition.side_effect = (
+            ValidationError("Some validation error message")
+        )
+
+        # CALL & ASSERT
+        with self.assertRaises(SystemExit) as err:
+            upload.upload_parameter_set(session, definition_path, json=json)
+
+        # ASSERT
+        self.mock_optional_echo.assert_called_once_with(
+            "Validating parameter set definition", json
+        )
+        self.mock_workflows_api.validate_parameter_set_definition.assert_called_once_with(
+            session, definition_path
+        )
+        self.assertEqual(err.exception.code, 1)
+        self.mock_workflows_api.upload_parameter_set.assert_not_called()
+        self.mock_print_json.assert_not_called()
+
+        self.mock_click.echo.assert_called_once_with(
+            self.mock_workflows_api.validate_parameter_set_definition.side_effect
+        )
+
+    def test_upload_parameter_set_exits_for_validation_error(self):
+        """Tests that upload_parameter_set works as expected when there is a
+        validation error and json = False"""
+        self._test_upload_parameter_set_exits_for_validation_error(json=False)
+
+    def test_upload_parameter_set_exits_for_validation_error_json(self):
+        """Tests that upload_parameter_set works as expected when there is a
+        validation error and json = True"""
+        self._test_upload_parameter_set_exits_for_validation_error(json=True)


### PR DESCRIPTION
Adds the --json flag to all upload commands - allowing the raw json responses from the upload to be printed. These will also skip confirmation like the -y flag and hide all other output (apart from errors).

e.g.
`dafni upload dataset new_dataset.json sunshine-tiny.zip --json`
![image](https://github.com/dafnifacility/cli/assets/90245114/bf3b9006-2a60-4f2d-8bba-7362e1cdcf78)

`dafni upload model model_definition.yaml very-small-zip.tar.gz -m "Initial upload" --json`
![image](https://github.com/dafnifacility/cli/assets/90245114/a3e05572-db5f-42ad-8b1e-1b82504b3314)

Workflows and their parameter sets will return their entire metadata.

This PR is quite large as I restructured all of the upload command unit tests to reduce code reuse.


Closes #60, Closes #61