### PR TITLE
feat: Automated PyPi publishing [CORE-3206]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,12 @@
+# This action:
+# - Builds a universal pip wheel and source distribution
+# - Installs and runs the unit tests on this wheel and then if successful:
+# - Generates a draft release on GitHub with build files already uploaded
+# - Uploads the build to test.pypi
+
+# To finally release see publish.yml which runs when the draft release is
+# published
+
 name: Build Python Package
 
 on:
@@ -36,9 +45,20 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
       - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: >
           gh release create --draft --repo ${{ github.repository }}
           ${{ github.ref_name }}
           artifact/*
-        env:
-          GH_TOKEN: ${{ github.token }}
+  publish_to_test_pypi:
+    needs: ['build']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: Publish to test.pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+# This action:
+# - Downloads all release files from the release that triggered it (whether it's a
+#   prerelease or full)
+# - Uploads these files to PyPi
+# This should follow on from build.yml - Only the files from /dist should be present
+# in the published release
+
+name: Publish Python Package to PyPi
+
+on:
+  # Release when either a full release or a pre-release is published
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+  release:
+    types: [published]
+
+jobs:
+  publish_to_pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release files
+        # Download all files from the release that was just published to /dist
+        # (github.ref should be the tag itself here)
+        run: |
+          gh release download -p "*" -D dist/ -R ${{ github.repository }} ${{ github.ref }}
+      - name: Publish to test.pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -79,11 +79,19 @@ ___
 
 ### Automated
 
-To deploy the CLI push version tags in the form of `v*.*.*`. This will run the GitHub build action, performing the build, unit tests on the built package, and then will draft a release under the GitHub releases tab. Then select the most recent tag and add any release notes and when ready publish the release to trigger the upload to PyPi. (This is not implemented just yet.)
+To deploy the CLI, push version tags in the form of `v*.*.*`. This will run the GitHub build action, performing the build, unit tests on the built package, and will then upload to test.pypi and draft a release under the GitHub releases tab.
+
+You should then check the correct tag is selected, select the checkbox labelled pre-release if required and add any release notes. You may also check the build uploaded to test.pypi by using
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ dafni-cli
+```
+
+When ready, publish the release to trigger the upload to PyPi.
 
 ### Manual
 
-You may wish to produce a build manually if you need to produce a build with a specific version number such as a pre-release. In this case you may temporarly force the version by modifying the `pyproject.toml` by replacing the lines
+Prior to producing a manual build you may wish to check what the version number of the CLI will be. This can be checked by running `python -m setuptools_git_versioning` in a clone of the repo. If you wish to force the version number you must modify the `pyproject.toml` by replacing the lines
 
 ```toml
 dynamic = ["version"]
@@ -91,7 +99,7 @@ dynamic = ["version"]
 [tool.setuptools-git-versioning]
 enabled = true
 ```
-with
+with the new version number e.g.
 ```toml
 version = "0.0.1rc1"
 ```
@@ -102,6 +110,11 @@ python -m build
 ```
 
 This will create a build and dist folder in the root folder, containing a `.tar.gz` and a `.whl` for the new version of the pip package ready to publish to pypi.
+
+You can check the build using
+```bash
+twine check ./dist/*
+```
 
 Manually uploading these to https://test.pypi.org/ can then be done with
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,6 @@ dynamic = ["version"]
 [tool.setuptools-git-versioning]
 enabled = true
 
-# To override the versioning above, comment out and replace with
-# version = "0.0.1"
-
 [project.urls]
 "Documentation" = "https://github.com/dafnifacility/cli/blob/main/docs/dafni_cli.md"
 "Release notes" = "https://github.com/dafnifacility/cli/releases"


### PR DESCRIPTION
Adds a step in the existing build action to upload to test.pypi. Then a 2nd action that runs when the draft release is actually published and downloads the /dist files and uploads them to pypi. Also updates the developer notes.

I can't really see a way to test all this properly without just trying it, although I did run some experiments on my own github repo to check that the download from release command functioned and works with pre release versions. The on release trigger in the GitHub docs (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release) also states that it should trigger for both prereleases and full releases.