### PR TITLE
feat: Add way to select dataset files to download [CORE-3217]

### DIFF
--- a/dafni_cli/commands/download.py
+++ b/dafni_cli/commands/download.py
@@ -5,7 +5,11 @@ import click
 from click import Context
 
 from dafni_cli.api.session import DAFNISession
-from dafni_cli.commands.helpers import cli_get_latest_dataset_metadata
+from dafni_cli.commands.helpers import (
+    cli_get_latest_dataset_metadata,
+    cli_select_dataset_files,
+)
+from dafni_cli.commands.options import click_optional_tuple_none_callback
 from dafni_cli.datasets.dataset_download import download_dataset
 from dafni_cli.datasets.dataset_metadata import parse_dataset_metadata
 
@@ -29,11 +33,27 @@ def download(ctx: Context):
     help="Directory to save the zipped Dataset files to. Default is the current working directory",
 )
 @click.argument("version-id", nargs=1, required=True, type=str)
+@click.option(
+    "--regex",
+    "-r",
+    type=str,
+    help="Regex that will match the names of the files you wish to download from the dataset",
+)
+@click.option(
+    "--file",
+    "-f",
+    type=str,
+    callback=click_optional_tuple_none_callback,
+    multiple=True,
+    help="Specific file names of files you wish to download from the dataset",
+)
 @click.pass_context
 def dataset(
     ctx: Context,
     version_id: List[str],
     directory: Optional[Path],
+    file: Optional[List[str]],
+    regex: Optional[str],
 ):
     """Download all files associated with the given Dataset Version.
 
@@ -42,13 +62,22 @@ def dataset(
         version_id (str): Dataset version ID
         directory (Optional[Path]): Directory to download files to (when None
                                     will use the current working directory)
+        file (Optional[List[str]]): List of specific file names to download
+        regex (Optional[str]): Regular expression to match with the names of
+                                the files to download
     """
     metadata = parse_dataset_metadata(
         cli_get_latest_dataset_metadata(ctx.obj["session"], version_id)
     )
 
     if len(metadata.files) > 0:
-        download_dataset(ctx.obj["session"], metadata.files, directory)
+        selected_files = cli_select_dataset_files(
+            metadata, file_names=file, file_regex=regex
+        )
+        if len(selected_files) > 0:
+            download_dataset(ctx.obj["session"], selected_files, directory)
+        else:
+            click.echo("No files selected to download")
     else:
         click.echo(
             "There are no files currently associated with the Dataset to download"

--- a/dafni_cli/commands/download.py
+++ b/dafni_cli/commands/download.py
@@ -33,27 +33,19 @@ def download(ctx: Context):
     help="Directory to save the zipped Dataset files to. Default is the current working directory",
 )
 @click.argument("version-id", nargs=1, required=True, type=str)
-@click.option(
-    "--regex",
-    "-r",
-    type=str,
-    help="Regex that will match the names of the files you wish to download from the dataset",
-)
-@click.option(
-    "--file",
-    "-f",
+@click.argument(
+    "files",
+    nargs=-1,
+    required=False,
     type=str,
     callback=click_optional_tuple_none_callback,
-    multiple=True,
-    help="Specific file names of files you wish to download from the dataset",
 )
 @click.pass_context
 def dataset(
     ctx: Context,
     version_id: List[str],
     directory: Optional[Path],
-    file: Optional[List[str]],
-    regex: Optional[str],
+    files: Optional[List[str]],
 ):
     """Download all files associated with the given Dataset Version.
 
@@ -62,18 +54,15 @@ def dataset(
         version_id (str): Dataset version ID
         directory (Optional[Path]): Directory to download files to (when None
                                     will use the current working directory)
-        file (Optional[List[str]]): List of specific file names to download
-        regex (Optional[str]): Regular expression to match with the names of
-                                the files to download
+        files (Optional[List[str]]): List of specific files to download (allows
+                                     glob-like wildcards)
     """
     metadata = parse_dataset_metadata(
         cli_get_latest_dataset_metadata(ctx.obj["session"], version_id)
     )
 
     if len(metadata.files) > 0:
-        selected_files = cli_select_dataset_files(
-            metadata, file_names=file, file_regex=regex
-        )
+        selected_files = cli_select_dataset_files(metadata, files=files)
         if len(selected_files) > 0:
             download_dataset(ctx.obj["session"], selected_files, directory)
         else:

--- a/dafni_cli/commands/helpers.py
+++ b/dafni_cli/commands/helpers.py
@@ -1,5 +1,4 @@
 import fnmatch
-import re
 from typing import List, Optional, Tuple
 
 import click
@@ -66,7 +65,6 @@ def cli_select_dataset_files(
         # Check if any one of the supplied file names matches
         for file_name in files:
             if fnmatch.fnmatch(file.name, file_name):
-                print(file.name, file_name)
                 selected_files.append(file)
                 break
 

--- a/dafni_cli/tests/commands/test_download.py
+++ b/dafni_cli/tests/commands/test_download.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List, Optional
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -30,55 +31,97 @@ class TestDownload(TestCase):
         self.assertEqual(result.exit_code, 0)
 
 
-@patch("dafni_cli.commands.download.DAFNISession")
-@patch("dafni_cli.commands.download.cli_get_latest_dataset_metadata")
-@patch("dafni_cli.commands.download.parse_dataset_metadata")
-@patch("dafni_cli.commands.download.download_dataset")
 class TestDownloadDataset(TestCase):
     """Test class to test the download dataset command"""
 
-    def test_download_dataset(
-        self,
-        mock_download_dataset,
-        mock_parse_dataset_metadata,
-        mock_cli_get_latest_dataset_metadata,
-        mock_DAFNISession,
-    ):
-        """Tests that the 'download dataset' command works correctly (with no
-        optional arguments)"""
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
+    def setUp(self) -> None:
+        super().setUp()
 
-        version_id = "version-id"
+        self.mock_DAFNISession = patch(
+            "dafni_cli.commands.download.DAFNISession"
+        ).start()
+        self.mock_cli_get_latest_dataset_metadata = patch(
+            "dafni_cli.commands.download.cli_get_latest_dataset_metadata"
+        ).start()
+        self.mock_cli_select_dataset_files = patch(
+            "dafni_cli.commands.download.cli_select_dataset_files"
+        ).start()
+        self.mock_parse_dataset_metadata = patch(
+            "dafni_cli.commands.download.parse_dataset_metadata"
+        ).start()
+        self.mock_download_dataset = patch(
+            "dafni_cli.commands.download.download_dataset"
+        ).start()
+
+        self.mock_session = MagicMock()
+        self.mock_DAFNISession.return_value = self.mock_session
+
+        # Mock metadata and files
+        self.version_id = "version-id"
         file_names = ["file_name1", "file_name2"]
         file_contents = ["file_contents1", "file_contents2"]
-        metadata = MagicMock()
-        metadata.dataset_id = "dataset-id"
-        metadata.files = [MagicMock(), MagicMock()]
-        metadata.download_dataset_files = MagicMock()
-        metadata.download_dataset_files.return_value = (
+        self.metadata = MagicMock()
+        self.metadata.dataset_id = "dataset-id"
+        self.metadata.files = [MagicMock(), MagicMock()]
+        self.metadata.download_dataset_files = MagicMock()
+        self.metadata.download_dataset_files.return_value = (
             file_names,
             file_contents,
         )
-        mock_parse_dataset_metadata.return_value = metadata
+        self.selected_dataset_files = [MagicMock() for file in self.metadata.files]
+        self.mock_parse_dataset_metadata.return_value = self.metadata
+        self.mock_cli_select_dataset_files.return_value = self.selected_dataset_files
+
+        self.addCleanup(patch.stopall)
+
+    def _run_command(
+        self,
+        directory: str,
+        file_names: Optional[List[str]],
+        file_regex: Optional[str],
+    ):
+        """Executes the 'download dataset' command and returns the result"""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            args = ["dataset", self.version_id]
+            if directory:
+                args.extend(["--directory", directory])
+                Path(directory).mkdir()
+            if file_names:
+                for file_name in file_names:
+                    args.extend(["--file", file_name])
+            if file_regex:
+                args.extend(["--regex", file_regex])
+
+            result = runner.invoke(download.download, args)
+
+        return result
+
+    def test_download_dataset(
+        self,
+    ):
+        """Tests that the 'download dataset' command works correctly (with no
+        optional arguments)"""
 
         # CALL
-        result = runner.invoke(download.download, ["dataset", version_id])
+        result = self._run_command(directory=None, file_names=None, file_regex=None)
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.version_id
         )
-        mock_parse_dataset_metadata.assert_called_once_with(
-            mock_cli_get_latest_dataset_metadata.return_value
+        self.mock_parse_dataset_metadata.assert_called_once_with(
+            self.mock_cli_get_latest_dataset_metadata.return_value
+        )
+        self.mock_cli_select_dataset_files.assert_called_once_with(
+            self.metadata, file_names=None, file_regex=None
         )
 
-        mock_download_dataset.assert_called_once_with(
-            session,
-            metadata.files,
+        self.mock_download_dataset.assert_called_once_with(
+            self.mock_session,
+            self.selected_dataset_files,
             None,
         )
 
@@ -86,53 +129,33 @@ class TestDownloadDataset(TestCase):
 
     def test_download_dataset_with_specific_directory(
         self,
-        mock_download_dataset,
-        mock_parse_dataset_metadata,
-        mock_cli_get_latest_dataset_metadata,
-        mock_DAFNISession,
     ):
         """Tests that the 'download dataset' command works correctly with a
         specific directory specified"""
-        # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
 
-        version_id = "version-id"
-        file_names = ["file_name1", "file_name2"]
-        file_contents = [b"file_contents1", b"file_contents2"]
+        # SETUP
         directory = "some_folder"
-        metadata = MagicMock()
-        metadata.dataset_id = "dataset-id"
-        metadata.files = [MagicMock(), MagicMock()]
-        metadata.download_dataset_files = MagicMock()
-        metadata.download_dataset_files.return_value = (
-            file_names,
-            file_contents,
-        )
-        mock_parse_dataset_metadata.return_value = metadata
 
         # CALL
-        with runner.isolated_filesystem():
-            Path(directory).mkdir()
-
-            result = runner.invoke(
-                download.download,
-                ["dataset", version_id, "--directory", directory],
-            )
+        result = self._run_command(
+            directory=directory, file_names=None, file_regex=None
+        )
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, version_id
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.version_id
         )
-        mock_parse_dataset_metadata.assert_called_once_with(
-            mock_cli_get_latest_dataset_metadata.return_value
+        self.mock_parse_dataset_metadata.assert_called_once_with(
+            self.mock_cli_get_latest_dataset_metadata.return_value
+        )
+        self.mock_cli_select_dataset_files.assert_called_once_with(
+            self.metadata, file_names=None, file_regex=None
         )
 
-        mock_download_dataset.assert_called_once_with(
-            session,
-            metadata.files,
+        self.mock_download_dataset.assert_called_once_with(
+            self.mock_session,
+            self.selected_dataset_files,
             Path(directory),
         )
 
@@ -140,38 +163,96 @@ class TestDownloadDataset(TestCase):
 
     def test_download_dataset_with_no_files(
         self,
-        mock_download_dataset,
-        mock_parse_dataset_metadata,
-        mock_cli_get_latest_dataset_metadata,
-        mock_DAFNISession,
     ):
         """Tests that the 'download dataset' command works correctly when
         there are no files to download"""
+
         # SETUP
-        session = MagicMock()
-        mock_DAFNISession.return_value = session
-        runner = CliRunner()
-        metadata = MagicMock()
-        metadata.dataset_id = "dataset-id"
-        metadata.files = []
-        mock_parse_dataset_metadata.return_value = metadata
+        self.metadata.files = []
 
         # CALL
-        result = runner.invoke(download.download, ["dataset", "version-id"])
+        result = self._run_command(directory=None, file_names=None, file_regex=None)
 
         # ASSERT
-        mock_DAFNISession.assert_called_once()
-        mock_cli_get_latest_dataset_metadata.assert_called_once_with(
-            session, "version-id"
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.version_id
         )
-        mock_parse_dataset_metadata.assert_called_once_with(
-            mock_cli_get_latest_dataset_metadata.return_value
+        self.mock_parse_dataset_metadata.assert_called_once_with(
+            self.mock_cli_get_latest_dataset_metadata.return_value
         )
-        mock_download_dataset.assert_not_called()
+        self.mock_cli_select_dataset_files.assert_not_called()
+        self.mock_download_dataset.assert_not_called()
 
         self.assertEqual(
             result.output,
             "There are no files currently associated with the Dataset to download\n",
+        )
+
+        self.assertEqual(result.exit_code, 0)
+
+    def test_download_dataset_with_file_names_and_regex_given(
+        self,
+    ):
+        """Tests that the 'download dataset' command works correctly (when given
+        a list of file names and regex to match to)"""
+
+        # CALL
+        file_names = ["filename1.zip", "filename2.zip"]
+        file_regex = r"^.+\.csv"
+        result = self._run_command(
+            directory=None, file_names=file_names, file_regex=file_regex
+        )
+
+        # ASSERT
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.version_id
+        )
+        self.mock_parse_dataset_metadata.assert_called_once_with(
+            self.mock_cli_get_latest_dataset_metadata.return_value
+        )
+        self.mock_cli_select_dataset_files.assert_called_once_with(
+            self.metadata, file_names=tuple(file_names), file_regex=file_regex
+        )
+
+        self.mock_download_dataset.assert_called_once_with(
+            self.mock_session,
+            self.selected_dataset_files,
+            None,
+        )
+
+        self.assertEqual(result.exit_code, 0)
+
+    def test_download_dataset_with_no_selected_files(
+        self,
+    ):
+        """Tests that the 'download dataset' command works correctly when
+        there are no selected files to download"""
+
+        # SETUP
+        self.selected_dataset_files = []
+        self.mock_cli_select_dataset_files.return_value = self.selected_dataset_files
+
+        # CALL
+        result = self._run_command(directory=None, file_names=None, file_regex=None)
+
+        # ASSERT
+        self.mock_DAFNISession.assert_called_once()
+        self.mock_cli_get_latest_dataset_metadata.assert_called_once_with(
+            self.mock_session, self.version_id
+        )
+        self.mock_parse_dataset_metadata.assert_called_once_with(
+            self.mock_cli_get_latest_dataset_metadata.return_value
+        )
+        self.mock_cli_select_dataset_files.assert_called_once_with(
+            self.metadata, file_names=None, file_regex=None
+        )
+        self.mock_download_dataset.assert_not_called()
+
+        self.assertEqual(
+            result.output,
+            "No files selected to download\n",
         )
 
         self.assertEqual(result.exit_code, 0)

--- a/dafni_cli/tests/commands/test_download.py
+++ b/dafni_cli/tests/commands/test_download.py
@@ -76,7 +76,7 @@ class TestDownloadDataset(TestCase):
 
     def _run_command(
         self,
-        directory: str,
+        directory: Optional[str],
         files: Optional[List[str]],
     ):
         """Executes the 'download dataset' command and returns the result"""
@@ -226,7 +226,8 @@ class TestDownloadDataset(TestCase):
         self.mock_cli_select_dataset_files.return_value = self.selected_dataset_files
 
         # CALL
-        result = self._run_command(directory=None, files=None)
+        files = ["filename1.zip", "filename2.zip", "*.csv"]
+        result = self._run_command(directory=None, files=files)
 
         # ASSERT
         self.mock_DAFNISession.assert_called_once()
@@ -237,7 +238,7 @@ class TestDownloadDataset(TestCase):
             self.mock_cli_get_latest_dataset_metadata.return_value
         )
         self.mock_cli_select_dataset_files.assert_called_once_with(
-            self.metadata, files=None
+            self.metadata, files=tuple(files)
         )
         self.mock_download_dataset.assert_not_called()
 

--- a/dafni_cli/tests/commands/test_download.py
+++ b/dafni_cli/tests/commands/test_download.py
@@ -77,8 +77,7 @@ class TestDownloadDataset(TestCase):
     def _run_command(
         self,
         directory: str,
-        file_names: Optional[List[str]],
-        file_regex: Optional[str],
+        files: Optional[List[str]],
     ):
         """Executes the 'download dataset' command and returns the result"""
         runner = CliRunner()
@@ -88,11 +87,8 @@ class TestDownloadDataset(TestCase):
             if directory:
                 args.extend(["--directory", directory])
                 Path(directory).mkdir()
-            if file_names:
-                for file_name in file_names:
-                    args.extend(["--file", file_name])
-            if file_regex:
-                args.extend(["--regex", file_regex])
+            if files:
+                args.extend([file_name for file_name in files])
 
             result = runner.invoke(download.download, args)
 
@@ -105,7 +101,7 @@ class TestDownloadDataset(TestCase):
         optional arguments)"""
 
         # CALL
-        result = self._run_command(directory=None, file_names=None, file_regex=None)
+        result = self._run_command(directory=None, files=None)
 
         # ASSERT
         self.mock_DAFNISession.assert_called_once()
@@ -116,7 +112,7 @@ class TestDownloadDataset(TestCase):
             self.mock_cli_get_latest_dataset_metadata.return_value
         )
         self.mock_cli_select_dataset_files.assert_called_once_with(
-            self.metadata, file_names=None, file_regex=None
+            self.metadata, files=None
         )
 
         self.mock_download_dataset.assert_called_once_with(
@@ -137,9 +133,7 @@ class TestDownloadDataset(TestCase):
         directory = "some_folder"
 
         # CALL
-        result = self._run_command(
-            directory=directory, file_names=None, file_regex=None
-        )
+        result = self._run_command(directory=directory, files=None)
 
         # ASSERT
         self.mock_DAFNISession.assert_called_once()
@@ -150,7 +144,7 @@ class TestDownloadDataset(TestCase):
             self.mock_cli_get_latest_dataset_metadata.return_value
         )
         self.mock_cli_select_dataset_files.assert_called_once_with(
-            self.metadata, file_names=None, file_regex=None
+            self.metadata, files=None
         )
 
         self.mock_download_dataset.assert_called_once_with(
@@ -171,7 +165,7 @@ class TestDownloadDataset(TestCase):
         self.metadata.files = []
 
         # CALL
-        result = self._run_command(directory=None, file_names=None, file_regex=None)
+        result = self._run_command(directory=None, files=None)
 
         # ASSERT
         self.mock_DAFNISession.assert_called_once()
@@ -191,18 +185,15 @@ class TestDownloadDataset(TestCase):
 
         self.assertEqual(result.exit_code, 0)
 
-    def test_download_dataset_with_file_names_and_regex_given(
+    def test_download_dataset_with_specific_files_given(
         self,
     ):
         """Tests that the 'download dataset' command works correctly (when given
-        a list of file names and regex to match to)"""
+        a list of files match to)"""
 
         # CALL
-        file_names = ["filename1.zip", "filename2.zip"]
-        file_regex = r"^.+\.csv"
-        result = self._run_command(
-            directory=None, file_names=file_names, file_regex=file_regex
-        )
+        files = ["filename1.zip", "filename2.zip", "*.csv"]
+        result = self._run_command(directory=None, files=files)
 
         # ASSERT
         self.mock_DAFNISession.assert_called_once()
@@ -213,7 +204,7 @@ class TestDownloadDataset(TestCase):
             self.mock_cli_get_latest_dataset_metadata.return_value
         )
         self.mock_cli_select_dataset_files.assert_called_once_with(
-            self.metadata, file_names=tuple(file_names), file_regex=file_regex
+            self.metadata, files=tuple(files)
         )
 
         self.mock_download_dataset.assert_called_once_with(
@@ -235,7 +226,7 @@ class TestDownloadDataset(TestCase):
         self.mock_cli_select_dataset_files.return_value = self.selected_dataset_files
 
         # CALL
-        result = self._run_command(directory=None, file_names=None, file_regex=None)
+        result = self._run_command(directory=None, files=None)
 
         # ASSERT
         self.mock_DAFNISession.assert_called_once()
@@ -246,7 +237,7 @@ class TestDownloadDataset(TestCase):
             self.mock_cli_get_latest_dataset_metadata.return_value
         )
         self.mock_cli_select_dataset_files.assert_called_once_with(
-            self.metadata, file_names=None, file_regex=None
+            self.metadata, files=None
         )
         self.mock_download_dataset.assert_not_called()
 

--- a/dafni_cli/tests/commands/test_helpers.py
+++ b/dafni_cli/tests/commands/test_helpers.py
@@ -102,8 +102,8 @@ class TestCliSelectDatasetFiles(TestCase):
         )
 
     def test_all_optionals_none_returns_whole_list(self):
-        """Tests that the entire list of files is returned when both file_regex
-        and file_names are None"""
+        """Tests that the entire list of files is returned when the given list
+        of files is None"""
         # CALL
         result = helpers.cli_select_dataset_files(self.dataset_metadata, files=None)
 

--- a/dafni_cli/tests/commands/test_helpers.py
+++ b/dafni_cli/tests/commands/test_helpers.py
@@ -105,20 +105,17 @@ class TestCliSelectDatasetFiles(TestCase):
         """Tests that the entire list of files is returned when both file_regex
         and file_names are None"""
         # CALL
-        result = helpers.cli_select_dataset_files(
-            self.dataset_metadata, file_regex=None, file_names=None
-        )
+        result = helpers.cli_select_dataset_files(self.dataset_metadata, files=None)
 
         # ASSERT
         self.assertEqual(result, self.dataset_metadata.files)
 
-    def test_file_names_selects_correct_files(self):
-        """Tests that only files found in file_names are returned when given"""
+    def test_given_exact_file_names_selects_correct_files(self):
+        """Tests that only files found in the given list of files are returned"""
         # CALL
         result = helpers.cli_select_dataset_files(
             self.dataset_metadata,
-            file_regex=None,
-            file_names=["file1.csv", "file2.zip"],
+            files=["file1.csv", "file2.zip"],
         )
 
         # ASSERT
@@ -126,14 +123,13 @@ class TestCliSelectDatasetFiles(TestCase):
             result, [self.dataset_metadata.files[0], self.dataset_metadata.files[1]]
         )
 
-    def test_file_regex_selects_correct_files(self):
-        """Tests that only files with names matching the file_regex are
-        returned when given"""
+    def test_given_file_wildcard_selects_correct_files(self):
+        """Tests that only files with names matching the given glob-like file
+        name is returned when given"""
         # CALL
         result = helpers.cli_select_dataset_files(
             self.dataset_metadata,
-            file_regex=r"^.+\.csv",
-            file_names=None,
+            files=["*.csv"],
         )
 
         # ASSERT
@@ -141,38 +137,17 @@ class TestCliSelectDatasetFiles(TestCase):
             result, [self.dataset_metadata.files[0], self.dataset_metadata.files[2]]
         )
 
-    def test_file_names_and_regex_selects_correct_files(self):
-        """Tests that only files with names found in file_names or that match
-        the file_regex are returned when both are given"""
+    def test_given_file_name_and_wildcard_selects_correct_files(self):
+        """Tests that only files with names found explicitly given or that match
+        the a separate glob-like filename are returned when both are given"""
         # CALL
         result = helpers.cli_select_dataset_files(
             self.dataset_metadata,
-            file_regex=r"^.+\.csv",
-            file_names=["file2.zip"],
+            files=["*.csv", "file2.zip"],
         )
 
         # ASSERT
         self.assertEqual(result, self.dataset_metadata.files)
-
-    @patch("dafni_cli.commands.helpers.click")
-    def test_missing_file_names_raises_system_exit(self, mock_click):
-        """Tests that when file_names is given but not all names are found
-        in the dataset a SystemExit is raised"""
-        # CALL & ASSERT
-        with self.assertRaises(SystemExit) as err:
-            helpers.cli_select_dataset_files(
-                self.dataset_metadata,
-                file_regex=r"^.+\.csv",
-                file_names=["file1.zip", "file2.zip", "file4.csv"],
-            )
-        self.assertEqual(
-            mock_click.echo.call_args_list,
-            [
-                call("The following files were not found in the dataset:"),
-                call("file1.zip\nfile4.csv"),
-            ],
-        )
-        self.assertEqual(err.exception.code, 1)
 
 
 @patch("dafni_cli.commands.helpers.get_workflow")

--- a/dafni_cli/tests/test_utils.py
+++ b/dafni_cli/tests/test_utils.py
@@ -1,7 +1,5 @@
-import tempfile
 from dataclasses import dataclass
 from datetime import datetime
-from io import BytesIO
 from pathlib import Path
 from typing import List, Optional
 from unittest import TestCase

--- a/docs/dafni_cli.md
+++ b/docs/dafni_cli.md
@@ -184,13 +184,21 @@ You may download all the files of a dataset using its version id via the command
 dafni download dataset <version-id>
 ```
 
-You may also select specific files by using the `--file <file_name>` option any number of times. For a more specific selection you may also use a regular expression, for example
+You may also select specific files by using their names e.g.
 
 ```bash
-dafni download dataset <version-id> --regex "^.+\.csv"
+dafni download dataset <version-id> file1.csv file2.zip
+```
+
+As with the dataset upload you may also use wildcards. For example
+
+```bash
+dafni download dataset <version-id> "*.csv"
 ```
 
 will download all `.csv` files in the dataset.
+
+> **_NOTE:_** You should use quotation marks, `""`, here to avoid any confusion with local files that may be in your current directory.
 
 ### Deleting entities
 
@@ -213,7 +221,7 @@ There are two options for datasets. You may either delete an entire dataset with
 dafni delete dataset <version-id>
 ```
 
-> **_NOTE_** This still takes a version id. It doesn't matter which is given in this case as it will delete the associated parent dataset
+> **_NOTE:_** This still takes a version id. It doesn't matter which is given in this case as it will delete the associated parent dataset
 
 or just a version with
 

--- a/docs/dafni_cli.md
+++ b/docs/dafni_cli.md
@@ -184,6 +184,14 @@ You may download all the files of a dataset using its version id via the command
 dafni download dataset <version-id>
 ```
 
+You may also select specific files by using the `--file <file_name>` option any number of times. For a more specific selection you may also use a regular expression, for example
+
+```bash
+dafni download dataset <version-id> --regex "^.+\.csv"
+```
+
+will download all `.csv` files in the dataset.
+
 ### Deleting entities
 
 You may delete entities on the platform using one of the `dafni delete` commands. All of these will take an existing version id for a dataset, model or workflow and will display a brief summary with a confirmation prompt prior to actual deletion. e.g.


### PR DESCRIPTION
Adds optional arguments to the `dafni dataset download` command that it can take any number of explicit file names or glob-like wildcards e.g.

`dafni download dataset <version_id> file1.csv file2.csv`

or

`dafni download dataset <version_id> "*.csv"`

Closes #106 