### PR TITLE
fix: Fix upload failing as not downloading artifact to dist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
+        with:
+          path: ./dist
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -56,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
+        with:
+          path: ./dist
       - name: Publish to test.pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Fixes an issue experienced https://github.com/dafnifacility/cli/actions/runs/5831728749/job/15815741184 where the artifact download from the build step downloaded files to an `artifact` folder instead of `dist`, breaking the upload to test.pypi.

The final upload should be unaffected as it already explicitly downloads to dist.