### PR TITLE
fix: Release upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
-        with:
-          path: ./dist
+      - name: Rename extracted folder
+        run: mv artifact dist
       - name: Create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -54,12 +54,15 @@ jobs:
           ${{ github.ref_name }}
           dist/*
   publish_to_test_pypi:
-    needs: ['build']
+    # Don't really need to wait on this but it will ensure that if
+    # unable to upload files from the downloaded artifact e.g. when the directory
+    # structure is wrong we wont try and upload it to test.pypi at all
+    needs: ['draft_release']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
-        with:
-          path: ./dist
+      - name: Rename extracted folder
+        run: mv artifact dist
       - name: Publish to test.pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
After #114 and #115, there was an additional issue - the download-artifact action extracted the artifact files in an artifact directory, so the previous PR actually ended up with files under artifact/dist instead of just /dist. This renames the directory instead.

Additionally I added a dependency on the draft_release to the publish_to_test_pypi step so that if it fails such as it did, it wont try and upload to test.pypi as previously I had to cancel it myself.

As a result of this I am postponing the beta release until next Tuesday as there may be further things to fix on the publish action and its Friday afternoon.