### PR TITLE
fix: Replace 'ref' with 'ref_name' for tag to download in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         # Download all files from the release that was just published to /dist
         # (github.ref should be the tag itself here)
         run: |
-          gh release download -p "*" -D dist/ -R ${{ github.repository }} ${{ github.ref }}
+          gh release download -p "*" -D dist/ -R ${{ github.repository }} ${{ github.ref_name }}
       - name: Publish to test.pypi
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Build action now works - Pushing a tag drafted a release and successfully uploaded to test.pypi. Unfortunately the ref used in the publish action included refs/head/v0.0.1b which broke the release download command as it should have been simply v0.0.1b. This replaces github.ref with ref_name to hopefully fix it.

I will delete and recreate the release once this is merged to trigger the action again.