### PR TITLE
fix: Add workaround to retry on SSLError

### DIFF
--- a/dafni_cli/api/minio_api.py
+++ b/dafni_cli/api/minio_api.py
@@ -41,7 +41,7 @@ def upload_file_to_minio(
 
             # In event of a refresh need to ensure file gets reset to start
             # as wont have uploaded anything
-            def refresh_callback():
+            def retry_callback():
                 file.seek(0)
                 prog_bar.reset()
 
@@ -49,7 +49,7 @@ def upload_file_to_minio(
                 url=url,
                 content_type=MINIO_UPLOAD_CT,
                 data=file_data,
-                refresh_callback=refresh_callback,
+                retry_callback=retry_callback,
             )
 
 

--- a/dafni_cli/consts.py
+++ b/dafni_cli/consts.py
@@ -110,6 +110,12 @@ TAB_SPACE = "    "
 # small enough to fit in memory and give a reasonable loading bar scale
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
+# Maximum number of times to retry requests that have SSLErrors
+MAX_SSL_ERROR_RETRY_ATTEMPTS = 3
+
+# Time to wait between retry attempts when an SSLError occurs (seconds)
+SSL_ERROR_RETRY_WAIT = 1
+
 # Data formats for datasets (See mimeTypes.js in front end)
 DATA_FORMATS = {
     "audio/3gpp": "3GPP Audio",

--- a/dafni_cli/tests/api/test_minio_api.py
+++ b/dafni_cli/tests/api/test_minio_api.py
@@ -31,8 +31,8 @@ class TestMinioAPI(TestCase):
         # Cause the refresh callback to be called
         put_request_return_value = MagicMock()
 
-        def put_request_side_effect(url, content_type, data, refresh_callback):
-            refresh_callback()
+        def put_request_side_effect(url, content_type, data, retry_callback):
+            retry_callback()
             return put_request_return_value
 
         session.put_request = MagicMock(side_effect=put_request_side_effect)
@@ -62,10 +62,10 @@ class TestMinioAPI(TestCase):
             url=url,
             content_type=MINIO_UPLOAD_CT,
             data=mock_CallbackIOWrapper.return_value,
-            refresh_callback=ANY,
+            retry_callback=ANY,
         )
 
-        # refresh_callback
+        # retry_callback
         open_mock.return_value.seek.assert_called_once_with(0)
         mock_progress_bar.reset.assert_called_once()
 


### PR DESCRIPTION
Retires 3 additional times when an SSLError occurs, waiting 1 second between each attempt. This will hopefully workaround #113.

Once merged I will create a tag for v0.0.1b2, then we can hopefully see if this resolves the issue.