### PR TITLE
fix: Batch get urls and upload files together [CORE-3337]

### DIFF
--- a/dafni_cli/consts.py
+++ b/dafni_cli/consts.py
@@ -116,6 +116,9 @@ MAX_SSL_ERROR_RETRY_ATTEMPTS = 3
 # Time to wait between retry attempts when an SSLError occurs (seconds)
 SSL_ERROR_RETRY_WAIT = 1
 
+# Number of files to upload in a single batch during dataset upload
+DATASET_UPLOAD_MAX_FILES_PER_BATCH = 10
+
 # Data formats for datasets (See mimeTypes.js in front end)
 DATA_FORMATS = {
     "audio/3gpp": "3GPP Audio",

--- a/dafni_cli/datasets/dataset_metadata.py
+++ b/dafni_cli/datasets/dataset_metadata.py
@@ -1,15 +1,12 @@
 from dataclasses import dataclass, field
 from datetime import datetime
-from io import BytesIO
-from typing import ClassVar, List, Optional, Tuple
+from typing import ClassVar, List, Optional
 
 import click
 from tabulate import tabulate
 
 from dafni_cli.api.auth import Auth
-from dafni_cli.api.minio_api import minio_get_request
 from dafni_cli.api.parser import ParserBaseObject, ParserParam, parse_datetime
-from dafni_cli.api.session import DAFNISession
 from dafni_cli.consts import (
     CONSOLE_WIDTH,
     TABLE_MODIFIED_HEADER,

--- a/dafni_cli/datasets/dataset_upload.py
+++ b/dafni_cli/datasets/dataset_upload.py
@@ -16,13 +16,19 @@ from dafni_cli.api.minio_api import (
     upload_file_to_minio,
 )
 from dafni_cli.api.session import DAFNISession
+from dafni_cli.consts import DATASET_UPLOAD_MAX_FILES_PER_BATCH
 from dafni_cli.datasets.dataset_metadata import (
     DATASET_METADATA_LANGUAGES,
     DATASET_METADATA_SUBJECTS,
     DATASET_METADATA_THEMES,
     DATASET_METADATA_UPDATE_FREQUENCIES,
 )
-from dafni_cli.utils import OverallFileProgressBar, optional_echo, print_json
+from dafni_cli.utils import (
+    OverallFileProgressBar,
+    optional_echo,
+    print_json,
+    split_list,
+)
 
 # Keys inside dataset metadata returned from the API that are invalid for
 # uploading
@@ -243,10 +249,10 @@ def upload_files(
         file_paths (List[Path]): List of Paths to dataset data files
         json (bool): Whether to print the raw json returned by the DAFNI API
     """
-    optional_echo("Retrieving file upload URls", json)
-    file_names_and_paths = {file_path.name: file_path for file_path in file_paths}
-    upload_urls = get_data_upload_urls(
-        session, temp_bucket_id, list(file_names_and_paths.keys())
+    # Split up file_paths into batches - Workaround for
+    # https://github.com/dafnifacility/cli/issues/113
+    file_paths_batches = list(
+        split_list(file_paths, DATASET_UPLOAD_MAX_FILES_PER_BATCH)
     )
 
     optional_echo("Uploading files", json)
@@ -258,16 +264,29 @@ def upload_files(
     with OverallFileProgressBar(
         len(file_paths), total_file_size
     ) as overall_progress_bar:
-        for file_name, file_upload_url in upload_urls["urls"].items():
-            upload_file_to_minio(
-                session,
-                file_upload_url,
-                file_names_and_paths[file_name],
-                progress_bar=not json,
+        # Obtain upload URLs for each batch separately and wait until uploaded
+        # all the files in the current batch before starting the next
+        for file_paths_batch in file_paths_batches:
+            file_names_and_paths = {
+                file_path.name: file_path for file_path in file_paths_batch
+            }
+
+            upload_urls = get_data_upload_urls(
+                session, temp_bucket_id, list(file_names_and_paths.keys())
             )
 
-            # Completed a file download, update the overall status to reflect
-            overall_progress_bar.update(file_names_and_paths[file_name].stat().st_size)
+            for file_name, file_upload_url in upload_urls["urls"].items():
+                upload_file_to_minio(
+                    session,
+                    file_upload_url,
+                    file_names_and_paths[file_name],
+                    progress_bar=not json,
+                )
+
+                # Completed a file download, update the overall status to reflect
+                overall_progress_bar.update(
+                    file_names_and_paths[file_name].stat().st_size
+                )
 
 
 def _commit_metadata(

--- a/dafni_cli/tests/test_utils.py
+++ b/dafni_cli/tests/test_utils.py
@@ -697,3 +697,57 @@ class TestIsValidImageFile(TestCase):
 
         # ASSERT
         self.assertFalse(result)
+
+
+class TestSplitList(TestCase):
+    """Test class to test the split_list function"""
+
+    def test_no_splitting_when_shorter_than_max_size(self):
+        """Tests split_list returns a generator that produces a list containing
+        the unmodified list when its length is shorter than max_size"""
+        # SETUP
+        list_length = 20
+        max_size = 100
+        lst = range(list_length)
+
+        # CALL
+        result = list(utils.split_list(lst=lst, max_size=max_size))
+
+        # ASSERT
+        self.assertEqual(result, [lst])
+
+    def test_splits_when_longer_than_max_size_when_fits_exactly(self):
+        """Tests split_list returns a generator that produces a list containing
+        many shorter lists not exceeding max_size when its length is longer
+        than max_size and the split list elements are all the same size"""
+        # SETUP
+        list_length = 20
+        max_size = 2
+        lst = list(range(list_length))
+
+        # CALL
+        result = list(utils.split_list(lst=lst, max_size=max_size))
+
+        # ASSERT
+        self.assertEqual(
+            result,
+            [list(range(i, i + max_size)) for i in range(0, list_length, max_size)],
+        )
+
+    def test_splits_when_longer_than_max_size_when_does_not_fit_exactly(self):
+        """Tests split_list returns a generator that produces a list containing
+        many shorter lists not exceeding max_size when its length is longer
+        than max_size and the array cannot be split into exact chunks"""
+        # SETUP
+        list_length = 20
+        max_size = 15
+        lst = list(range(list_length))
+
+        # CALL
+        result = list(utils.split_list(lst=lst, max_size=max_size))
+
+        # ASSERT
+        self.assertEqual(
+            result,
+            [list(range(0, max_size)), list(range(max_size, list_length))],
+        )

--- a/dafni_cli/utils.py
+++ b/dafni_cli/utils.py
@@ -340,3 +340,19 @@ def is_valid_image_file(file_name: Path):
         return file_type in acceptable_file_types
     except:
         return False
+
+
+def split_list(lst: List, max_size: int):
+    """Splits a given list into 'max_size' or smaller lists
+
+    Args:
+        lst (List): List to split
+        max_size: Maximum size of any given list returned
+
+    Returns:
+        Generator[List]: A generator that returns a list with a maximum
+                         size max_size e.g. use list(list_split(lst, max_size))
+
+    """
+    for i in range(0, len(lst), max_size):
+        yield lst[i : i + max_size]


### PR DESCRIPTION
Implements Rose's suggestion for another potential fix to #113 - batching the get urls call and file upload for dataset upload into batches of 10.

Will release as v0.0.1b3 after David has had a chance to check a non-work laptop - Regardless of whether that works or not, this may be another way to get round it and is I think more preferable than having the CLI get a list of all urls to upload to before uploading anything as although unlikely they do timeout eventually (24 hours currently).