### PR TITLE
fix: Attempt to fix long upload errors

### DIFF
--- a/dafni_cli/api/exceptions.py
+++ b/dafni_cli/api/exceptions.py
@@ -2,6 +2,10 @@ class LoginError(Exception):
     """Generic error to distinguish login failures"""
 
 
+class AuthenticationError(Exception):
+    """Generic error to distinguish an authentication error"""
+
+
 class DAFNIError(Exception):
     """An error returned by one of the DAFNI API's"""
 

--- a/dafni_cli/api/session.py
+++ b/dafni_cli/api/session.py
@@ -359,6 +359,8 @@ class DAFNISession:
 
         Raises:
             LoginError: If unable to login or refresh tokens to authenticate
+            RuntimeError: If some other error repeatedly occurs e.g. an SSLError
+                          (See https://github.com/dafnifacility/cli/issues/113)
         """
 
         # Should we retry the request for any reason

--- a/dafni_cli/consts.py
+++ b/dafni_cli/consts.py
@@ -110,11 +110,12 @@ TAB_SPACE = "    "
 # small enough to fit in memory and give a reasonable loading bar scale
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 
-# Maximum number of times to retry requests that have SSLErrors
-MAX_SSL_ERROR_RETRY_ATTEMPTS = 3
+# Maximum number of times to retry requests that have failed due to an error
+REQUEST_ERROR_RETRY_ATTEMPTS = 3
 
-# Time to wait between retry attempts when an SSLError occurs (seconds)
-SSL_ERROR_RETRY_WAIT = 1
+# Time to wait between retry attempts when an error occurs during a
+# request (seconds)
+REQUEST_ERROR_RETRY_WAIT = 1
 
 # Number of files to upload in a single batch during dataset upload
 DATASET_UPLOAD_MAX_FILES_PER_BATCH = 10

--- a/dafni_cli/consts.py
+++ b/dafni_cli/consts.py
@@ -115,7 +115,10 @@ REQUEST_ERROR_RETRY_ATTEMPTS = 3
 
 # Time to wait between retry attempts when an error occurs during a
 # request (seconds)
-REQUEST_ERROR_RETRY_WAIT = 3
+REQUEST_ERROR_RETRY_WAIT = 1
+
+# Number of upload attempts to make when there is a problem during dataset upload
+DATASET_UPLOAD_FILE_RETRY_ATTEMPTS = 3
 
 # Number of files to upload in a single batch during dataset upload
 DATASET_UPLOAD_MAX_FILES_PER_BATCH = 10

--- a/dafni_cli/consts.py
+++ b/dafni_cli/consts.py
@@ -115,7 +115,7 @@ REQUEST_ERROR_RETRY_ATTEMPTS = 3
 
 # Time to wait between retry attempts when an error occurs during a
 # request (seconds)
-REQUEST_ERROR_RETRY_WAIT = 1
+REQUEST_ERROR_RETRY_WAIT = 3
 
 # Number of files to upload in a single batch during dataset upload
 DATASET_UPLOAD_MAX_FILES_PER_BATCH = 10

--- a/dafni_cli/tests/api/test_session.py
+++ b/dafni_cli/tests/api/test_session.py
@@ -13,10 +13,10 @@ from dafni_cli.api.session import DAFNISession, LoginError
 from dafni_cli.consts import (
     LOGIN_API_ENDPOINT,
     LOGOUT_API_ENDPOINT,
-    MAX_SSL_ERROR_RETRY_ATTEMPTS,
+    REQUEST_ERROR_RETRY_ATTEMPTS,
     REQUESTS_TIMEOUT,
     SESSION_COOKIE,
-    SSL_ERROR_RETRY_WAIT,
+    REQUEST_ERROR_RETRY_WAIT,
     URLS_REQUIRING_COOKIE_AUTHENTICATION,
 )
 from dafni_cli.tests.fixtures.session import (
@@ -1125,8 +1125,8 @@ class TestDAFNISession(TestCase):
         self.assertEqual(self.mock_requests.request.call_count, 2)
 
     @patch("dafni_cli.api.session.time")
-    def test_retry_on_ssl_error(self, mock_time):
-        """Tests that when requests raises an SSLError the request is retired
+    def test_retry_on_error(self, mock_time):
+        """Tests that when requests raises an error the request is retired
         multiple times while waiting in between before finally giving a
         RuntimeError"""
 
@@ -1142,7 +1142,7 @@ class TestDAFNISession(TestCase):
         self.mock_requests.exceptions.SSLError = requests.exceptions.SSLError
 
         # 3 retries = 4 attempts
-        expected_number_of_attempts = MAX_SSL_ERROR_RETRY_ATTEMPTS + 1
+        expected_number_of_attempts = REQUEST_ERROR_RETRY_ATTEMPTS + 1
         self.mock_requests.request.side_effect = [requests.exceptions.SSLError] * (
             expected_number_of_attempts
         )
@@ -1159,9 +1159,9 @@ class TestDAFNISession(TestCase):
         )
         self.assertEqual(
             mock_time.sleep.call_args_list,
-            [call(SSL_ERROR_RETRY_WAIT)] * MAX_SSL_ERROR_RETRY_ATTEMPTS,
+            [call(REQUEST_ERROR_RETRY_WAIT)] * REQUEST_ERROR_RETRY_ATTEMPTS,
         )
         self.assertEqual(
             str(err.exception),
-            f"Could not connect due to an SSLError after retrying {MAX_SSL_ERROR_RETRY_ATTEMPTS} times",
+            f"Could not connect due to an error after retrying {REQUEST_ERROR_RETRY_ATTEMPTS} times",
         )

--- a/dafni_cli/tests/api/test_session.py
+++ b/dafni_cli/tests/api/test_session.py
@@ -1028,7 +1028,7 @@ class TestDAFNISession(TestCase):
         self.assertEqual(str(error.exception), "Unable to refresh login.")
 
     def test_refresh_runtime_error(self):
-        """Tests a RuntimeError is raised when refreshing a token fails"""
+        """Tests a LoginError is raised when refreshing a token fails"""
 
         session = self.create_mock_session(True)
 
@@ -1042,7 +1042,7 @@ class TestDAFNISession(TestCase):
         # New token
         self.mock_requests.post.return_value = create_mock_access_token_response()
 
-        with self.assertRaises(RuntimeError) as error:
+        with self.assertRaises(LoginError) as error:
             # Avoid creating any local files
             with patch(
                 "builtins.open", new_callable=mock_open, read_data=TEST_SESSION_FILE


### PR DESCRIPTION
Removes file batching so one get presigned url -> one file upload (This seemingly prolongs the error)
Then obtains a new URL when there are repeated errors that are not fixed by retrying the request alone.

I have repeatedly ran this method, most recently on 600 files, totalling 12 GB, and it was successful where it had previously failed. #113 

Will release as v0.0.1b4