### PR TITLE
fix: Preemptively refresh token when close to expiry

### DIFF
--- a/dafni_cli/api/session.py
+++ b/dafni_cli/api/session.py
@@ -63,7 +63,7 @@ class SessionData:
         Constructs a session data object and returns it
 
         The timestamp_to_refresh parameter will be set to the current time
-        + the expiry time - the TOKEN_EXPIRE_OFFSET.
+        + the token's time to expiry - the TOKEN_EXPIRE_OFFSET.
 
         Args:
             username (str): Username to identify the session with
@@ -214,11 +214,6 @@ class DAFNISession:
             datetime.datetime.now().timestamp()
             >= self._session_data.timestamp_to_refresh
         ):
-            print(
-                "NEW REFRESH",
-                datetime.datetime.now().timestamp()
-                - self._session_data.timestamp_to_refresh,
-            )
             # Need a refresh
             self._refresh_tokens()
 

--- a/dafni_cli/api/session.py
+++ b/dafni_cli/api/session.py
@@ -1,5 +1,5 @@
+import datetime
 import json
-from multiprocessing import AuthenticationError
 import os
 import time
 from dataclasses import dataclass
@@ -16,11 +16,12 @@ from dafni_cli.consts import (
     LOGIN_API_ENDPOINT,
     LOGOUT_API_ENDPOINT,
     REQUEST_ERROR_RETRY_ATTEMPTS,
+    REQUEST_ERROR_RETRY_WAIT,
     REQUESTS_TIMEOUT,
     SENDER_TYPE,
     SESSION_COOKIE,
     SESSION_SAVE_FILE,
-    REQUEST_ERROR_RETRY_WAIT,
+    TOKEN_EXPIRE_OFFSET,
     URLS_REQUIRING_COOKIE_AUTHENTICATION,
 )
 from dafni_cli.utils import dataclass_from_dict
@@ -32,13 +33,18 @@ class LoginResponse:
 
     access_token: Optional[str] = None
     refresh_token: Optional[str] = None
+    expires_in: Optional[int] = None
 
     def was_successful(self):
         """
         Returns whether this login response represents a successful login
         """
 
-        return self.access_token is not None and self.refresh_token is not None
+        return (
+            self.access_token is not None
+            and self.refresh_token is not None
+            and self.expires_in is not None
+        )
 
 
 @dataclass
@@ -49,11 +55,15 @@ class SessionData:
     username: str
     access_token: str
     refresh_token: str
+    timestamp_to_refresh: float
 
     @staticmethod
     def from_login_response(username: str, login_response: LoginResponse):
         """
         Constructs a session data object and returns it
+
+        The timestamp_to_refresh parameter will be set to the current time
+        + the expiry time - the TOKEN_EXPIRE_OFFSET.
 
         Args:
             username (str): Username to identify the session with
@@ -61,10 +71,15 @@ class SessionData:
                                             from logging in
         """
 
+        datetime_to_refresh = datetime.datetime.now() + datetime.timedelta(
+            seconds=login_response.expires_in - TOKEN_EXPIRE_OFFSET
+        )
+
         return SessionData(
             username=username,
             access_token=login_response.access_token,
             refresh_token=login_response.refresh_token,
+            timestamp_to_refresh=datetime_to_refresh.timestamp(),
         )
 
 
@@ -187,6 +202,25 @@ class DAFNISession:
 
             if self._use_session_data_file:
                 self._save_session_data()
+
+    def _check_and_refresh_tokens(self):
+        """Checks whether the current stored token will expire soon, and if
+        so will attempt to refresh it
+
+        Raises:
+            LoginError: If unable to login or gain a new refresh token
+        """
+        if (
+            datetime.datetime.now().timestamp()
+            >= self._session_data.timestamp_to_refresh
+        ):
+            print(
+                "NEW REFRESH",
+                datetime.datetime.now().timestamp()
+                - self._session_data.timestamp_to_refresh,
+            )
+            # Need a refresh
+            self._refresh_tokens()
 
     def logout(self):
         """Logs out of keycloak"""
@@ -345,9 +379,10 @@ class DAFNISession:
             allow_redirect (bool): Flag to allow redirects during API call.
             stream (Optional[bool]): Whether to stream the request
             retry_callback (Optional[Callable]): Function called when the
-                             request is retried e.g. after a token refresh
-                             or if there is an SSLError. Particularly useful
-                             for file uploads that may need to be reset.
+                             request is retried e.g. after a token refresh after an
+                             initial request is sent or if there is an SSLError.
+                             Particularly useful for file uploads that may need to
+                             be reset.
             auth_recursion_level (int): Number of times this method has
                              been recursively called due to an authentication
                              issue (Used to avoid infinite loops)
@@ -363,6 +398,10 @@ class DAFNISession:
             RuntimeError: If some other error repeatedly occurs e.g. an SSLError
                           (See https://github.com/dafnifacility/cli/issues/113)
         """
+
+        # Before doing anything check whether the current token will expire
+        # soon and refresh if so
+        self._check_and_refresh_tokens()
 
         # Should we retry the request for any reason
         retry = False

--- a/dafni_cli/consts.py
+++ b/dafni_cli/consts.py
@@ -38,6 +38,10 @@ LOGOUT_API_ENDPOINT = f"{KEYCLOAK_API_URL}/auth/realms/{KEYCLOAK_API_REALM}/prot
 SESSION_SAVE_FILE = ".dafni-cli"
 SESSION_COOKIE = "__Secure-dafni"
 
+# Time before a token expires that we should refresh the token regardless
+# of any authentication errors (seconds) - 60 matches VueKeyCloak
+TOKEN_EXPIRE_OFFSET = 60
+
 # Content types
 MINIO_UPLOAD_CT = "multipart/form-data"
 VALIDATE_MODEL_CT = "application/yaml"

--- a/dafni_cli/tests/fixtures/session.py
+++ b/dafni_cli/tests/fixtures/session.py
@@ -11,6 +11,7 @@ TEST_SESSION_DATA = SessionData(
     username="test_username",
     access_token=TEST_ACCESS_TOKEN,
     refresh_token="some_refresh_token",
+    timestamp_to_refresh=float("inf"),
 )
 TEST_SESSION_FILE = f"{json.dumps(TEST_SESSION_DATA.__dict__)}"
 
@@ -48,6 +49,7 @@ def create_mock_access_token_response():
         {
             "access_token": TEST_ACCESS_TOKEN,
             "refresh_token": "some_refresh_token",
+            "expires_in": 300,
         },
     )
 


### PR DESCRIPTION
Had some strange errors on staging that I think was caused by the token becoming invalid after the request was sent but before it was completed by the NID. This was difficult to recreate and I have never seen it before on production but to be safe I implemented this anyway to refresh the token when around 60 seconds or closer to becoming invalid as found in `VueKeyCloak`.  It could in theory replace the current refresh mechanism when a 403/302 error is returned but being so close to releasing I thought it wiser to leave the rest as it is to avoid breaking any of the error messages.