### PR TITLE
fix: Fix delete dataset-version doing nothing

### DIFF
--- a/dafni_cli/api/datasets_api.py
+++ b/dafni_cli/api/datasets_api.py
@@ -173,5 +173,5 @@ def delete_dataset_version(session: DAFNISession, version_id: str) -> Response:
         session (DAFNISession): User session
         version_id (str): Dataset version ID for the selected dataset version
     """
-    url = f"{NID_API_URL}/nid/version/{version_id}"
+    url = f"{NID_API_URL}/nid/version/{version_id}/"
     return session.delete_request(url)

--- a/dafni_cli/tests/api/test_datasets_api.py
+++ b/dafni_cli/tests/api/test_datasets_api.py
@@ -230,6 +230,6 @@ class TestDatasetsAPI(TestCase):
 
         # ASSERT
         session.delete_request.assert_called_once_with(
-            f"{NID_API_URL}/nid/version/{version_id}",
+            f"{NID_API_URL}/nid/version/{version_id}/",
         )
         self.assertEqual(result, session.delete_request.return_value)


### PR DESCRIPTION
This was modified in the NID two months ago causing the CLI to do nothing when calling the endpoint. Now it flags for deletion like it should. I double checked workflows and models and they remain unchanged.