### PR TITLE
fix: creates folder structure for dataset download

### DIFF
--- a/dafni_cli/datasets/dataset_download.py
+++ b/dafni_cli/datasets/dataset_download.py
@@ -41,6 +41,7 @@ def download_dataset(
         # Each file downloaded individually with its own progress bar
         for file in files:
             file_save_path = directory / file.name
+            file_save_path.parent.mkdir(exist_ok=True, parents=True)
 
             # Stream the file download
             with minio_get_request(


### PR DESCRIPTION
Datasets where file names are a path were failing to download. This fix ensures the directories exist before attempting to write files