### PR TITLE
Handle parameter set upload failures gracefully

### DIFF
--- a/dafni_cli/tests/workflows/test_upload.py
+++ b/dafni_cli/tests/workflows/test_upload.py
@@ -214,10 +214,10 @@ class TestParameterSetUpload(TestCase):
 
     def test_upload_parameter_set_exits_for_dafni_error(self):
         """Tests that upload_parameter_set works as expected when there is a
-        validation error and json = False"""
+        dafni error and json = False"""
         self._test_upload_parameter_set_exits_for_dafni_error(json=False)
 
     def test_upload_parameter_set_exits_for_dafni_error_json(self):
         """Tests that upload_parameter_set works as expected when there is a
-        validation error and json = True"""
+        dafni error and json = True"""
         self._test_upload_parameter_set_exits_for_dafni_error(json=True)

--- a/dafni_cli/tests/workflows/test_upload.py
+++ b/dafni_cli/tests/workflows/test_upload.py
@@ -173,7 +173,7 @@ class TestParameterSetUpload(TestCase):
         validation error and json = True"""
         self._test_upload_parameter_set_exits_for_validation_error(json=True)
 
-    def test_upload_parameter_set_exits_for_dafni_error(self, json: bool):
+    def _test_upload_parameter_set_exits_for_dafni_error(self, json: bool):
         """Tests that upload_parameter_set works as expected when there is a
         dafni error with a given value of json"""
         # SETUP
@@ -211,3 +211,13 @@ class TestParameterSetUpload(TestCase):
         self.mock_click.echo.assert_called_once_with(
             self.mock_workflows_api.upload_parameter_set.side_effect
         )
+
+    def test_upload_parameter_set_exits_for_dafni_error(self):
+        """Tests that upload_parameter_set works as expected when there is a
+        validation error and json = False"""
+        self._test_upload_parameter_set_exits_for_dafni_error(json=False)
+
+    def test_upload_parameter_set_exits_for_dafni_error_json(self):
+        """Tests that upload_parameter_set works as expected when there is a
+        validation error and json = True"""
+        self._test_upload_parameter_set_exits_for_dafni_error(json=True)

--- a/dafni_cli/tests/workflows/test_upload.py
+++ b/dafni_cli/tests/workflows/test_upload.py
@@ -173,7 +173,7 @@ class TestParameterSetUpload(TestCase):
         validation error and json = True"""
         self._test_upload_parameter_set_exits_for_validation_error(json=True)
 
-    def _test_upload_parameter_set_exits_for_dafni_error(self, json: bool):
+    def test_upload_parameter_set_exits_for_dafni_error(self, json: bool):
         """Tests that upload_parameter_set works as expected when there is a
         dafni error with a given value of json"""
         # SETUP

--- a/dafni_cli/tests/workflows/test_upload.py
+++ b/dafni_cli/tests/workflows/test_upload.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, call, patch
 
-from dafni_cli.api.exceptions import ValidationError
+from dafni_cli.api.exceptions import DAFNIError, ValidationError
 from dafni_cli.tests.fixtures.workflow_parameter_set import TEST_WORKFLOW_PARAMETER_SET
 from dafni_cli.tests.fixtures.workflows import TEST_WORKFLOW
 from dafni_cli.workflows import upload
@@ -172,3 +172,42 @@ class TestParameterSetUpload(TestCase):
         """Tests that upload_parameter_set works as expected when there is a
         validation error and json = True"""
         self._test_upload_parameter_set_exits_for_validation_error(json=True)
+
+    def _test_upload_parameter_set_exits_for_dafni_error(self, json: bool):
+        """Tests that upload_parameter_set works as expected when there is a
+        dafni error with a given value of json"""
+        # SETUP
+        session = MagicMock()
+        definition_path = Path("path/to/definition")
+
+        self.mock_workflows_api.upload_parameter_set.side_effect = DAFNIError(
+            "Some ingestion error message"
+        )
+
+        # CALL & ASSERT
+        with self.assertRaises(SystemExit) as err:
+            upload.upload_parameter_set(session, definition_path, json=json)
+
+        # ASSERT
+        self.assertEqual(
+            self.mock_optional_echo.call_args_list,
+            [
+                call("Validating parameter set definition", json),
+                call("Uploading parameter set", json),
+            ],
+        )
+
+        self.mock_workflows_api.validate_parameter_set_definition.assert_called_once_with(
+            session, definition_path
+        )
+
+        self.mock_workflows_api.upload_parameter_set.assert_called_once_with(
+            session, definition_path
+        )
+
+        self.assertEqual(err.exception.code, 1)
+        self.mock_print_json.assert_not_called()
+
+        self.mock_click.echo.assert_called_once_with(
+            self.mock_workflows_api.upload_parameter_set.side_effect
+        )

--- a/dafni_cli/workflows/upload.py
+++ b/dafni_cli/workflows/upload.py
@@ -4,7 +4,7 @@ from typing import Optional
 import click
 
 import dafni_cli.api.workflows_api as workflows_api
-from dafni_cli.api.exceptions import ValidationError
+from dafni_cli.api.exceptions import DAFNIError, ValidationError
 from dafni_cli.api.session import DAFNISession
 from dafni_cli.utils import optional_echo, print_json
 
@@ -59,7 +59,12 @@ def upload_parameter_set(session: DAFNISession, definition: Path, json: bool = F
         raise SystemExit(1) from err
 
     optional_echo("Uploading parameter set", json)
-    details = workflows_api.upload_parameter_set(session, definition)
+
+    try:
+        details = workflows_api.upload_parameter_set(session, definition)
+    except DAFNIError as err:
+        click.echo(err)
+        raise SystemExit(1) from err
 
     # Output details
     if json:


### PR DESCRIPTION
Part of core-3407 - handles errors thrown during the actual parameter set upload.