### PR TITLE
feat: update setup for use with staging

### DIFF
--- a/dafni_cli/api/session.py
+++ b/dafni_cli/api/session.py
@@ -24,6 +24,7 @@ from dafni_cli.consts import (
     SESSION_SAVE_FILE,
     TOKEN_EXPIRE_OFFSET,
     URLS_REQUIRING_COOKIE_AUTHENTICATION,
+    VERIFY,
 )
 from dafni_cli.utils import dataclass_from_dict, get_current_messages
 
@@ -187,6 +188,7 @@ class DAFNISession:
                 "refresh_token": self._session_data.refresh_token,
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=VERIFY,
         )
 
         if response.status_code == 400 and response.json()["error"] == "invalid_grant":
@@ -235,6 +237,7 @@ class DAFNISession:
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=VERIFY,
         )
 
         response.raise_for_status()
@@ -262,6 +265,7 @@ class DAFNISession:
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=VERIFY,
         )
 
         # When status_code is 401 => The username or password is wrong and
@@ -431,6 +435,7 @@ class DAFNISession:
                     stream=stream,
                     timeout=REQUESTS_TIMEOUT,
                     cookies={SESSION_COOKIE: self._session_data.access_token},
+                    verify=VERIFY,
                 )
             else:
                 response = requests.request(
@@ -445,6 +450,7 @@ class DAFNISession:
                     allow_redirects=allow_redirect,
                     stream=stream,
                     timeout=REQUESTS_TIMEOUT,
+                    verify=VERIFY,
                 )
 
             # Check for any kind of authentication error, or an attempted redirect

--- a/dafni_cli/consts.py
+++ b/dafni_cli/consts.py
@@ -125,6 +125,9 @@ REQUEST_ERROR_RETRY_ATTEMPTS = 3
 # request (seconds)
 REQUEST_ERROR_RETRY_WAIT = 1
 
+# Sets whether certificates need validating for the request
+VERIFY = True
+
 # Number of upload attempts to make when there is a problem during dataset upload
 DATASET_UPLOAD_FILE_RETRY_ATTEMPTS = 3
 

--- a/dafni_cli/tests/api/test_session.py
+++ b/dafni_cli/tests/api/test_session.py
@@ -280,6 +280,7 @@ class TestDAFNISession(TestCase):
                         "scope": "openid",
                     },
                     timeout=REQUESTS_TIMEOUT,
+                    verify=True,
                 ),
                 call(
                     LOGIN_API_ENDPOINT,
@@ -1151,6 +1152,7 @@ class TestDAFNISession(TestCase):
                         "refresh_token": "some_refresh_token",
                     },
                     timeout=REQUESTS_TIMEOUT,
+                    verify=True,
                 ),
                 # New token request
                 call(

--- a/dafni_cli/tests/api/test_session.py
+++ b/dafni_cli/tests/api/test_session.py
@@ -292,6 +292,7 @@ class TestDAFNISession(TestCase):
                         "scope": "openid",
                     },
                     timeout=REQUESTS_TIMEOUT,
+                    verify=True,
                 ),
             ]
         )
@@ -1165,6 +1166,7 @@ class TestDAFNISession(TestCase):
                         "scope": "openid",
                     },
                     timeout=REQUESTS_TIMEOUT,
+                    verify=True,
                 ),
             ]
         )

--- a/dafni_cli/tests/api/test_session.py
+++ b/dafni_cli/tests/api/test_session.py
@@ -238,7 +238,7 @@ class TestDAFNISession(TestCase):
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
-            verify=True
+            verify=True,
         )
 
         self.assertEqual(err.exception.code, 1)

--- a/dafni_cli/tests/api/test_session.py
+++ b/dafni_cli/tests/api/test_session.py
@@ -103,6 +103,7 @@ class TestDAFNISession(TestCase):
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
         self.assertEqual(
@@ -157,6 +158,7 @@ class TestDAFNISession(TestCase):
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
         self.assertEqual(
@@ -196,6 +198,7 @@ class TestDAFNISession(TestCase):
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
         self.assertEqual(
@@ -235,6 +238,7 @@ class TestDAFNISession(TestCase):
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True
         )
 
         self.assertEqual(err.exception.code, 1)
@@ -326,6 +330,7 @@ class TestDAFNISession(TestCase):
                 "scope": "openid",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
     def test_get_error_message_with_no_error(self):
@@ -490,6 +495,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
     def _test_authenticated_request_cookie_auth(self, url: str):
@@ -518,6 +524,7 @@ class TestDAFNISession(TestCase):
             stream=None,
             timeout=REQUESTS_TIMEOUT,
             cookies={SESSION_COOKIE: TEST_ACCESS_TOKEN},
+            verify=True,
         )
 
     def test_authenticated_request_cookie_auth(self):
@@ -551,6 +558,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=False,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -592,6 +600,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=True,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -624,6 +633,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -664,6 +674,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -696,6 +707,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -734,6 +746,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -766,6 +779,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -806,6 +820,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -837,6 +852,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -872,6 +888,7 @@ class TestDAFNISession(TestCase):
             allow_redirects=False,
             stream=None,
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
         session._check_response.assert_called_once_with(
             "some_test_url",
@@ -918,6 +935,7 @@ class TestDAFNISession(TestCase):
                 "refresh_token": "some_refresh_token",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
         # Ensure get request is attempted again (should be successful the
@@ -977,6 +995,7 @@ class TestDAFNISession(TestCase):
                 "refresh_token": "some_refresh_token",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
         # Ensure get request is attempted again (should be successful the
@@ -1023,6 +1042,7 @@ class TestDAFNISession(TestCase):
                 "refresh_token": "some_refresh_token",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
         # Ensure get request is attempted again (should be successful the
@@ -1187,6 +1207,7 @@ class TestDAFNISession(TestCase):
                 "refresh_token": "some_refresh_token",
             },
             timeout=REQUESTS_TIMEOUT,
+            verify=True,
         )
 
         # Should only try request once as refreshes before called in this case

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -37,7 +37,7 @@ This ensures any modifications are applied to the CLI itself.
 
 ## Running against staging
 
-To run the CLI against staging, modify the `ENVIRONMENT` variable in `consts.py` to be `staging` instead of `production`.
+To run the CLI against staging, modify the `ENVIRONMENT` variable in `consts.py` to be `staging` instead of `production`. You may also need to set the `VERIFY` variable, located in the same file, to be `False` to avoid SSL errors during development. 
 
 ## Running the tests
 Whilst running the activated venv created locally for the dafni-cli, ensure you are in the root directory of the git repository, and use the following to run all tests:


### PR DESCRIPTION
Updates the developer notes for setting up staging. When working against staging the requests need `verify=False` to be set. This work informs developers of this and introduces a new constant to allow this to easily be set.