### PR TITLE
fix: Catalogue call error

### DIFF
--- a/dafni_cli/api/datasets_api.py
+++ b/dafni_cli/api/datasets_api.py
@@ -12,7 +12,7 @@ from dafni_cli.api.exceptions import (
 from dafni_cli.api.session import DAFNISession
 from dafni_cli.consts import NID_API_URL, SEARCH_AND_DISCOVERY_API_URL
 
-MAX_DATASETS = 20000
+MAX_DATASETS = 15000
 
 
 # Validation function for validating the dataset-metadata

--- a/dafni_cli/datasets/dataset.py
+++ b/dafni_cli/datasets/dataset.py
@@ -40,9 +40,9 @@ class Dataset(ParserBaseObject):
     metadata_id: str
     modified_date: datetime
     source: str
-    status: str
     subject: str
     title: str
+    status: str = "Unknown"
     formats: List[str] = field(default_factory=list)
     description: Optional[str] = None
     date_range_start: Optional[datetime] = None


### PR DESCRIPTION
This reduces the MAX_DATASETS to 15000 to work with Opensearch and adds a default status for older datasets with the field missing